### PR TITLE
Added userns option to containers

### DIFF
--- a/docker/resource_docker_container.go
+++ b/docker/resource_docker_container.go
@@ -420,6 +420,12 @@ func resourceDockerContainer() *schema.Resource {
 				},
 				Set: resourceDockerUploadHash,
 			},
+
+			"userns": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }

--- a/docker/resource_docker_container_funcs.go
+++ b/docker/resource_docker_container_funcs.go
@@ -111,6 +111,7 @@ func resourceDockerContainerCreate(d *schema.ResourceData, meta interface{}) err
 		LogConfig: dc.LogConfig{
 			Type: d.Get("log_driver").(string),
 		},
+		UsernsMode: d.Get("userns").(string),
 	}
 
 	if len(portBindings) != 0 {

--- a/docker/resource_docker_container_test.go
+++ b/docker/resource_docker_container_test.go
@@ -203,6 +203,10 @@ func TestAccDockerContainer_customized(t *testing.T) {
 			return fmt.Errorf("Container has incorrect extra host string: %q", c.HostConfig.ExtraHosts[1])
 		}
 
+		if c.HostConfig.UsernsMode != "host" {
+			return fmt.Errorf("Container has incorrect user namespace string: %q", c.HostConfig.UsernsMode)
+		}
+
 		if _, ok := c.NetworkSettings.Networks["test"]; !ok {
 			return fmt.Errorf("Container is not connected to the right user defined network: test")
 		}
@@ -386,6 +390,8 @@ resource "docker_container" "foo" {
 		host = "testhost2"
 		ip = "10.0.2.0"
 	}
+
+	userns = "host"
 }
 
 resource "docker_network" "test_network" {

--- a/docker/resource_docker_container_test.go
+++ b/docker/resource_docker_container_test.go
@@ -92,6 +92,32 @@ func TestAccDockerContainer_volume(t *testing.T) {
 	})
 }
 
+func TestAccDockerContainer_userNSDefault(t *testing.T) {
+	var c dc.Container
+
+	testCheck := func(*terraform.State) error {
+		if c.HostConfig.UsernsMode != "" {
+			return fmt.Errorf("User NS mode was not set correct: expected \"\", got %s", c.HostConfig.UsernsMode)
+		}
+
+		return nil
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDockerContainerUserNSVolumeDefaultConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccContainerRunning("docker_container.foo", &c),
+					testCheck,
+				),
+			},
+		},
+	})
+}
+
 func TestAccDockerContainer_customized(t *testing.T) {
 	var c dc.Container
 
@@ -412,5 +438,16 @@ resource "docker_container" "foo" {
 		content = "foo"
 		file = "/terraform/test.txt"
 	}
+}
+`
+
+const testAccDockerContainerUserNSVolumeDefaultConfig = `
+resource "docker_image" "foo" {
+	name = "nginx:latest"
+}
+
+resource "docker_container" "foo" {
+	name = "tf-test"
+	image = "${docker_image.foo.latest}"
 }
 `

--- a/website/docs/r/container.html.markdown
+++ b/website/docs/r/container.html.markdown
@@ -83,6 +83,7 @@ The following arguments are supported:
   container is.
 * `destroy_grace_seconds` - (Optional, int) If defined will attempt to stop the container before destroying. Container will be destroyed after `n` seconds or on successful stop.
 * `upload` - (Optional, block) See [File Upload](#upload) below for details.
+* `userns` - (Optional, string) The usernamespace to use for the container.
 
 <a id="capabilities"></a>
 ### Capabilities


### PR DESCRIPTION
userns allows users to set the user namespace to use when launching
containers. This is particularly important for systems with user
namespacing enabled and running containers that interface with the
Docker host (such as a CI system).