### PR TITLE
Upgrade go-dockerclient to version 1.2.0

### DIFF
--- a/vendor/github.com/fsouza/go-dockerclient/Gopkg.toml
+++ b/vendor/github.com/fsouza/go-dockerclient/Gopkg.toml
@@ -12,11 +12,15 @@
 
 [[constraint]]
   name = "github.com/google/go-cmp"
-  version = "v0.2.0"
+  branch = "master"
 
 [[constraint]]
   name = "github.com/gorilla/mux"
   version = "v1.5.0"
+
+[[constraint]]
+  name = "golang.org/x/net"
+  branch = "master"
 
 [[override]]
   name = "github.com/Nvveen/Gotty"

--- a/vendor/github.com/fsouza/go-dockerclient/Makefile
+++ b/vendor/github.com/fsouza/go-dockerclient/Makefile
@@ -2,22 +2,27 @@
 	all \
 	lint \
 	vet \
+	fmt \
 	fmtcheck \
 	pretest \
 	test \
-	integration
+	integration \
+	clean
 
 all: test
 
 lint:
-	@ go get -v golang.org/x/lint/golint
+	@ go get -v github.com/golang/lint/golint
 	[ -z "$$(golint . | grep -v 'type name will be used as docker.DockerInfo' | grep -v 'context.Context should be the first' | tee /dev/stderr)" ]
 
 vet:
-	go vet ./...
+	go vet $$(go list ./... | grep -v vendor)
+
+fmt:
+	gofmt -s -w $$(go list ./... | grep -v vendor)
 
 fmtcheck:
-	[ -z "$$(gofmt -s -d *.go ./testing | tee /dev/stderr)" ]
+	[ -z "$$(gofmt -s -d $$(go list ./... | grep -v vendor) | tee /dev/stderr)" ]
 
 testdeps:
 	go get -u github.com/golang/dep/cmd/dep
@@ -26,9 +31,12 @@ testdeps:
 pretest: testdeps lint vet fmtcheck
 
 gotest:
-	go test -race ./...
+	go test -race $$(go list ./... | grep -v vendor)
 
 test: pretest gotest
 
 integration:
 	go test -tags docker_integration -run TestIntegration -v
+
+clean:
+	go clean ./...

--- a/vendor/github.com/fsouza/go-dockerclient/appveyor.yml
+++ b/vendor/github.com/fsouza/go-dockerclient/appveyor.yml
@@ -5,6 +5,7 @@ clone_folder: c:\gopath\src\github.com\fsouza\go-dockerclient
 environment:
   GOPATH: c:\gopath
   matrix:
+    - GOVERSION: 1.8.7
     - GOVERSION: 1.9.4
     - GOVERSION: 1.10
 install:

--- a/vendor/github.com/fsouza/go-dockerclient/client.go
+++ b/vendor/github.com/fsouza/go-dockerclient/client.go
@@ -10,7 +10,6 @@ package docker
 import (
 	"bufio"
 	"bytes"
-	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -35,6 +34,8 @@ import (
 	"github.com/docker/docker/pkg/homedir"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/pkg/stdcopy"
+	"golang.org/x/net/context"
+	"golang.org/x/net/context/ctxhttp"
 )
 
 const (
@@ -223,13 +224,11 @@ func NewVersionedClient(endpoint string, apiVersionString string) (*Client, erro
 
 // WithTransport replaces underlying HTTP client of Docker Client by accepting
 // a function that returns pointer to a transport object.
-func (c *Client) WithTransport(trFunc func() *http.Transport) {
+func (c *Client) WithTransport(trFunc func () *http.Transport) {
 	c.initializeNativeClient(trFunc)
 }
 
-// NewVersionnedTLSClient is like NewVersionedClient, but with ann extra n.
-//
-// Deprecated: Use NewVersionedTLSClient instead.
+// NewVersionnedTLSClient has been DEPRECATED, please use NewVersionedTLSClient.
 func NewVersionnedTLSClient(endpoint string, cert, key, ca, apiVersionString string) (*Client, error) {
 	return NewVersionedTLSClient(endpoint, cert, key, ca, apiVersionString)
 }
@@ -476,7 +475,7 @@ func (c *Client) do(method, path string, doOptions doOptions) (*http.Response, e
 		ctx = context.Background()
 	}
 
-	resp, err := c.HTTPClient.Do(req.WithContext(ctx))
+	resp, err := ctxhttp.Do(ctx, c.HTTPClient, req)
 	if err != nil {
 		if strings.Contains(err.Error(), "connection refused") {
 			return nil, ErrConnectionRefused
@@ -592,7 +591,7 @@ func (c *Client) stream(method, path string, streamOptions streamOptions) error 
 			return chooseError(subCtx, err)
 		}
 	} else {
-		if resp, err = c.HTTPClient.Do(req.WithContext(subCtx)); err != nil {
+		if resp, err = ctxhttp.Do(subCtx, c.HTTPClient, req); err != nil {
 			if strings.Contains(err.Error(), "connection refused") {
 				return ErrConnectionRefused
 			}
@@ -915,10 +914,6 @@ func addQueryStringValue(items url.Values, key string, v reflect.Value) {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		if v.Int() > 0 {
 			items.Add(key, strconv.FormatInt(v.Int(), 10))
-		}
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		if v.Uint() > 0 {
-			items.Add(key, strconv.FormatUint(v.Uint(), 10))
 		}
 	case reflect.Float32, reflect.Float64:
 		if v.Float() > 0 {

--- a/vendor/github.com/fsouza/go-dockerclient/client_unix.go
+++ b/vendor/github.com/fsouza/go-dockerclient/client_unix.go
@@ -14,7 +14,7 @@ import (
 
 // initializeNativeClient initializes the native Unix domain socket client on
 // Unix-style operating systems
-func (c *Client) initializeNativeClient(trFunc func() *http.Transport) {
+func (c *Client) initializeNativeClient(trFunc func () *http.Transport) {
 	if c.endpointURL.Scheme != unixProtocol {
 		return
 	}

--- a/vendor/github.com/fsouza/go-dockerclient/client_windows.go
+++ b/vendor/github.com/fsouza/go-dockerclient/client_windows.go
@@ -9,8 +9,8 @@ package docker
 import (
 	"context"
 	"net"
-	"net/http"
 	"time"
+	"net/http"
 
 	"github.com/Microsoft/go-winio"
 )
@@ -26,7 +26,7 @@ func (p pipeDialer) Dial(network, address string) (net.Conn, error) {
 }
 
 // initializeNativeClient initializes the native Named Pipe client for Windows
-func (c *Client) initializeNativeClient(trFunc func() *http.Transport) {
+func (c *Client) initializeNativeClient(trFunc func () *http.Transport) {
 	if c.endpointURL.Scheme != namedPipeProtocol {
 		return
 	}

--- a/vendor/github.com/fsouza/go-dockerclient/container.go
+++ b/vendor/github.com/fsouza/go-dockerclient/container.go
@@ -5,7 +5,6 @@
 package docker
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -17,6 +16,7 @@ import (
 	"time"
 
 	units "github.com/docker/go-units"
+	"golang.org/x/net/context"
 )
 
 // ErrContainerAlreadyExists is the error returned by CreateContainer when the
@@ -1287,10 +1287,9 @@ func (c *Client) DownloadFromContainer(id string, opts DownloadFromContainerOpti
 	})
 }
 
-// CopyFromContainerOptions contains the set of options used for copying
-// files from a container.
+// CopyFromContainerOptions has been DEPRECATED, please use DownloadFromContainerOptions along with DownloadFromContainer.
 //
-// Deprecated: Use DownloadFromContainerOptions and DownloadFromContainer instead.
+// See https://goo.gl/nWk2YQ for more details.
 type CopyFromContainerOptions struct {
 	OutputStream io.Writer `json:"-"`
 	Container    string    `json:"-"`
@@ -1298,9 +1297,9 @@ type CopyFromContainerOptions struct {
 	Context      context.Context `json:"-"`
 }
 
-// CopyFromContainer copies files from a container.
+// CopyFromContainer has been DEPRECATED, please use DownloadFromContainerOptions along with DownloadFromContainer.
 //
-// Deprecated: Use DownloadFromContainer and DownloadFromContainer instead.
+// See https://goo.gl/nWk2YQ for more details.
 func (c *Client) CopyFromContainer(opts CopyFromContainerOptions) error {
 	if opts.Container == "" {
 		return &NoSuchContainer{ID: opts.Container}

--- a/vendor/github.com/fsouza/go-dockerclient/exec.go
+++ b/vendor/github.com/fsouza/go-dockerclient/exec.go
@@ -5,7 +5,6 @@
 package docker
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -13,6 +12,8 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+
+	"golang.org/x/net/context"
 )
 
 // Exec is the type representing a `docker exec` instance and containing the

--- a/vendor/github.com/fsouza/go-dockerclient/image.go
+++ b/vendor/github.com/fsouza/go-dockerclient/image.go
@@ -6,7 +6,6 @@ package docker
 
 import (
 	"bytes"
-	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -17,6 +16,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"golang.org/x/net/context"
 )
 
 // APIImages represent an image returned in the ListImages call.

--- a/vendor/github.com/fsouza/go-dockerclient/network.go
+++ b/vendor/github.com/fsouza/go-dockerclient/network.go
@@ -5,11 +5,12 @@
 package docker
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+
+	"golang.org/x/net/context"
 )
 
 // ErrNetworkAlreadyExists is the error returned by CreateNetwork when the

--- a/vendor/github.com/fsouza/go-dockerclient/plugin.go
+++ b/vendor/github.com/fsouza/go-dockerclient/plugin.go
@@ -5,10 +5,11 @@
 package docker
 
 import (
-	"context"
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+
+	"golang.org/x/net/context"
 )
 
 // PluginPrivilege represents a privilege for a plugin.

--- a/vendor/github.com/fsouza/go-dockerclient/swarm.go
+++ b/vendor/github.com/fsouza/go-dockerclient/swarm.go
@@ -5,7 +5,6 @@
 package docker
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -13,6 +12,7 @@ import (
 	"strconv"
 
 	"github.com/docker/docker/api/types/swarm"
+	"golang.org/x/net/context"
 )
 
 var (

--- a/vendor/github.com/fsouza/go-dockerclient/swarm_configs.go
+++ b/vendor/github.com/fsouza/go-dockerclient/swarm_configs.go
@@ -5,13 +5,13 @@
 package docker
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/url"
 	"strconv"
 
 	"github.com/docker/docker/api/types/swarm"
+	"golang.org/x/net/context"
 )
 
 // NoSuchConfig is the error returned when a given config does not exist.

--- a/vendor/github.com/fsouza/go-dockerclient/swarm_node.go
+++ b/vendor/github.com/fsouza/go-dockerclient/swarm_node.go
@@ -5,13 +5,13 @@
 package docker
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/url"
 	"strconv"
 
 	"github.com/docker/docker/api/types/swarm"
+	"golang.org/x/net/context"
 )
 
 // NoSuchNode is the error returned when a given node does not exist.

--- a/vendor/github.com/fsouza/go-dockerclient/swarm_secrets.go
+++ b/vendor/github.com/fsouza/go-dockerclient/swarm_secrets.go
@@ -5,13 +5,13 @@
 package docker
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/url"
 	"strconv"
 
 	"github.com/docker/docker/api/types/swarm"
+	"golang.org/x/net/context"
 )
 
 // NoSuchSecret is the error returned when a given secret does not exist.

--- a/vendor/github.com/fsouza/go-dockerclient/swarm_task.go
+++ b/vendor/github.com/fsouza/go-dockerclient/swarm_task.go
@@ -5,11 +5,11 @@
 package docker
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 
 	"github.com/docker/docker/api/types/swarm"
+	"golang.org/x/net/context"
 )
 
 // NoSuchTask is the error returned when a given task does not exist.

--- a/vendor/github.com/fsouza/go-dockerclient/volume.go
+++ b/vendor/github.com/fsouza/go-dockerclient/volume.go
@@ -5,10 +5,11 @@
 package docker
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
+
+	"golang.org/x/net/context"
 )
 
 var (
@@ -21,18 +22,17 @@ var (
 
 // Volume represents a volume.
 //
-// See https://goo.gl/3wgTsd for more details.
+// See https://goo.gl/FZA4BK for more details.
 type Volume struct {
 	Name       string            `json:"Name" yaml:"Name" toml:"Name"`
 	Driver     string            `json:"Driver,omitempty" yaml:"Driver,omitempty" toml:"Driver,omitempty"`
 	Mountpoint string            `json:"Mountpoint,omitempty" yaml:"Mountpoint,omitempty" toml:"Mountpoint,omitempty"`
 	Labels     map[string]string `json:"Labels,omitempty" yaml:"Labels,omitempty" toml:"Labels,omitempty"`
-	Options    map[string]string `json:"Options,omitempty" yaml:"Options,omitempty" toml:"Options,omitempty"`
 }
 
 // ListVolumesOptions specify parameters to the ListVolumes function.
 //
-// See https://goo.gl/3wgTsd for more details.
+// See https://goo.gl/FZA4BK for more details.
 type ListVolumesOptions struct {
 	Filters map[string][]string
 	Context context.Context
@@ -40,7 +40,7 @@ type ListVolumesOptions struct {
 
 // ListVolumes returns a list of available volumes in the server.
 //
-// See https://goo.gl/3wgTsd for more details.
+// See https://goo.gl/FZA4BK for more details.
 func (c *Client) ListVolumes(opts ListVolumesOptions) ([]Volume, error) {
 	resp, err := c.do("GET", "/volumes?"+queryString(opts), doOptions{
 		context: opts.Context,
@@ -70,7 +70,7 @@ func (c *Client) ListVolumes(opts ListVolumesOptions) ([]Volume, error) {
 
 // CreateVolumeOptions specify parameters to the CreateVolume function.
 //
-// See https://goo.gl/qEhmEC for more details.
+// See https://goo.gl/pBUbZ9 for more details.
 type CreateVolumeOptions struct {
 	Name       string
 	Driver     string
@@ -81,7 +81,7 @@ type CreateVolumeOptions struct {
 
 // CreateVolume creates a volume on the server.
 //
-// See https://goo.gl/qEhmEC for more details.
+// See https://goo.gl/pBUbZ9 for more details.
 func (c *Client) CreateVolume(opts CreateVolumeOptions) (*Volume, error) {
 	resp, err := c.do("POST", "/volumes/create", doOptions{
 		data:    opts,
@@ -100,7 +100,7 @@ func (c *Client) CreateVolume(opts CreateVolumeOptions) (*Volume, error) {
 
 // InspectVolume returns a volume by its name.
 //
-// See https://goo.gl/GMjsMc for more details.
+// See https://goo.gl/0g9A6i for more details.
 func (c *Client) InspectVolume(name string) (*Volume, error) {
 	resp, err := c.do("GET", "/volumes/"+name, doOptions{})
 	if err != nil {
@@ -119,28 +119,9 @@ func (c *Client) InspectVolume(name string) (*Volume, error) {
 
 // RemoveVolume removes a volume by its name.
 //
-// Deprecated: Use RemoveVolumeWithOptions instead.
+// See https://goo.gl/79GNQz for more details.
 func (c *Client) RemoveVolume(name string) error {
-	return c.RemoveVolumeWithOptions(RemoveVolumeOptions{Name: name})
-}
-
-// RemoveVolumeOptions specify parameters to the RemoveVolumeWithOptions
-// function.
-//
-// See https://goo.gl/nvd6qj for more details.
-type RemoveVolumeOptions struct {
-	Context context.Context
-	Name    string `qs:"-"`
-	Force   bool
-}
-
-// RemoveVolumeWithOptions removes a volume by its name and takes extra
-// parameters.
-//
-// See https://goo.gl/nvd6qj for more details.
-func (c *Client) RemoveVolumeWithOptions(opts RemoveVolumeOptions) error {
-	path := "/volumes/" + opts.Name
-	resp, err := c.do("DELETE", path+"?"+queryString(opts), doOptions{context: opts.Context})
+	resp, err := c.do("DELETE", "/volumes/"+name, doOptions{})
 	if err != nil {
 		if e, ok := err.(*Error); ok {
 			if e.Status == http.StatusNotFound {
@@ -158,7 +139,7 @@ func (c *Client) RemoveVolumeWithOptions(opts RemoveVolumeOptions) error {
 
 // PruneVolumesOptions specify parameters to the PruneVolumes function.
 //
-// See https://goo.gl/f9XDem for more details.
+// See https://goo.gl/pFN1Hj for more details.
 type PruneVolumesOptions struct {
 	Filters map[string][]string
 	Context context.Context
@@ -166,7 +147,7 @@ type PruneVolumesOptions struct {
 
 // PruneVolumesResults specify results from the PruneVolumes function.
 //
-// See https://goo.gl/f9XDem for more details.
+// See https://goo.gl/pFN1Hj for more details.
 type PruneVolumesResults struct {
 	VolumesDeleted []string
 	SpaceReclaimed int64
@@ -174,7 +155,7 @@ type PruneVolumesResults struct {
 
 // PruneVolumes deletes volumes which are unused.
 //
-// See https://goo.gl/f9XDem for more details.
+// See https://goo.gl/pFN1Hj for more details.
 func (c *Client) PruneVolumes(opts PruneVolumesOptions) (*PruneVolumesResults, error) {
 	path := "/volumes/prune?" + queryString(opts)
 	resp, err := c.do("POST", path, doOptions{context: opts.Context})

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -425,10 +425,12 @@
 			"revisionTime": "2017-12-21T20:03:56Z"
 		},
 		{
-			"checksumSHA1": "LxmlsftDto7ZuwfNmJRdKPah1t8=",
+			"checksumSHA1": "PtiR2n8s2cmePoDOkjT/wP1pfxA=",
 			"path": "github.com/fsouza/go-dockerclient",
-			"revision": "bf3bc17bb026cbe5e9203374f9a1ce37e521a364",
-			"revisionTime": "2018-03-03T17:22:32Z"
+			"revision": "ca33ff277b527ce11b793e62f9ba244129b01caf",
+			"revisionTime": "2018-02-18T05:12:31Z",
+			"version": "v1.2.0",
+			"versionExact": "v1.2.0"
 		},
 		{
 			"checksumSHA1": "1K+xrZ1PBez190iGt5OnMtGdih4=",


### PR DESCRIPTION
Hi there!

This is my first PR to a golang project, kindly let me know if I'm doing anything obviously wrong :-)

Following discussion in issue #52, I'm submitting an upgrade to `go-dockerclient` in order to get native support for Windows named pipes.  This should allow this terraform provider to contact the Docker daemon in "Docker for Windows".  In particular, it should enable the following syntax:

```
provider "docker" {
  host = "npipe:////./pipe/docker_engine"
}
```

I followed the instructions that @mavogel kindly supplied.  I have not yet tested the result of this PR against Docker for Windows, but I'm hoping that the upgrade is desirable regardless of issue #52.

Let me know if this submission needs more work before you consider accepting it :-)