### PR TITLE
Travis build uses docker version 18.03.0 to fix the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
 - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 - sudo apt-get update
-- sudo apt-get -y install docker-ce
+- sudo apt-get -y install docker-ce=18.03.0~ce-0~ubuntu
 - docker version
 - export TRAVIS="true"
 


### PR DESCRIPTION
- fixes `travis` build by adding the docker version `18.03.0`
- apparently, docker changed something in version `18.04.0`. See  for example https://travis-ci.org/terraform-providers/terraform-provider-docker/builds/368443868