### PR TITLE
Add batch file clones of the unix shell scripts

### DIFF
--- a/scripts/runAccTests.bat
+++ b/scripts/runAccTests.bat
@@ -70,7 +70,7 @@ exit /b %outcome%
   call:print "### unsetted env ###"
   for /F %%p in ('docker container ls -f "name=private_registry" -q') do (
     call docker stop %%p
-    call docker rm -f %%p
+    call docker rm -f -v %%p
   )
   call:print "### stopped private registry ###"
   rmdir /q /s %~dp0testing\auth
@@ -78,9 +78,13 @@ exit /b %outcome%
   call:print "### removed auth and certs ###"
   for %%r in ("container" "volume") do (
     call docker %%r ls -f "name=tftest-" -q
+    for /F %%i in ('docker %%r ls -f "name=tf-test" -q') do (
+      echo Deleting %%r %%i
+      call docker %%r rm -f -v %%i
+    )
     for /F %%i in ('docker %%r ls -f "name=tftest-" -q') do (
       echo Deleting %%r %%i
-      call docker %%r rm -f %%i
+      call docker %%r rm -f -v %%i
     )
     call:print "### removed %%r ###"
   )

--- a/scripts/runAccTests.bat
+++ b/scripts/runAccTests.bat
@@ -1,10 +1,16 @@
 @echo off
 setlocal
 
-set DOCKER_REGISTRY_ADDRESS="127.0.0.1:15000"
-set DOCKER_REGISTRY_USER="testuser"
-set DOCKER_REGISTRY_PASS="testpwd"
-set DOCKER_PRIVATE_IMAGE="127.0.0.1:15000/tftest-service:v1"
+:: As of `go-dockerclient` v1.2.0, the default endpoint to the Docker daemon
+:: is a UNIX socket.  We need to force it to use the Windows named pipe when
+:: running against Docker for Windows.
+set DOCKER_HOST=npipe:////.//pipe//docker_engine
+
+:: Note: quoting these values breaks the tests!
+set DOCKER_REGISTRY_ADDRESS=127.0.0.1:15000
+set DOCKER_REGISTRY_USER=testuser
+set DOCKER_REGISTRY_PASS=testpwd
+set DOCKER_PRIVATE_IMAGE=127.0.0.1:15000/tftest-service:v1
 set TF_ACC=1
 
 call:setup

--- a/scripts/runAccTests.bat
+++ b/scripts/runAccTests.bat
@@ -1,0 +1,94 @@
+@echo off
+setlocal
+
+set DOCKER_REGISTRY_ADDRESS="127.0.0.1:15000"
+set DOCKER_REGISTRY_USER="testuser"
+set DOCKER_REGISTRY_PASS="testpwd"
+set DOCKER_PRIVATE_IMAGE="127.0.0.1:15000/tftest-service:v1"
+set TF_ACC=1
+
+call:setup
+if %ErrorLevel% neq 0 (
+  call:print "Failed to set up acceptance test fixtures."
+  exit /b %ErrorLevel%
+)
+
+call:run
+if %ErrorLevel% neq 0 (
+  call:print "Acceptance tests failed."
+  set outcome=1
+) else (
+  set outcome=0
+)
+
+call:cleanup
+if %ErrorLevel% neq 0 (
+  call:print "Failed to clean up acceptance test fixtures."
+  exit /b %ErrorLevel%
+)
+
+exit /b %outcome%
+
+
+:print
+  if "%~1" == "" (
+    echo.
+  ) else (
+    echo %~1
+  ) 
+  exit /b 0
+
+
+:log
+  call:print ""
+  call:print "##################################"
+  call:print "-------- %~1"
+  call:print "##################################"
+  exit /b 0
+
+
+:setup
+  call:log "setup"
+  call %~dp0testing\setup_private_registry.bat
+  exit /b %ErrorLevel%
+
+
+:run
+  call:log "run"
+  call go test ./docker -v -timeout 120m
+  exit /b %ErrorLevel%
+
+
+:cleanup
+  call:log "cleanup"
+  call:print "### unsetted env ###"
+  for /F %%p in ('docker container ls -f "name=private_registry" -q') do (
+    call docker stop %%p
+    call docker rm -f %%p
+  )
+  call:print "### stopped private registry ###"
+  rmdir /q /s %~dp0testing\auth
+  rmdir /q /s %~dp0testing\certs
+  call:print "### removed auth and certs ###"
+  for %%r in ("container" "volume") do (
+    call docker %%r ls -f "name=tftest-" -q
+    for /F %%i in ('docker %%r ls -f "name=tftest-" -q') do (
+      echo Deleting %%r %%i
+      call docker %%r rm -f %%i
+    )
+    call:print "### removed %%r ###"
+  )
+  for %%r in ("config" "secret" "network") do (
+    call docker %%r ls -f "name=tftest-" -q
+    for /F %%i in ('docker %%r ls -f "name=tftest-" -q') do (
+      echo Deleting %%r %%i
+      call docker %%r rm %%i
+    )
+    call:print "### removed %%r ###"
+  )
+  for /F %%i in ('docker images -aq 127.0.0.1:5000/tftest-service') do (
+    echo Deleting imag %%i
+    docker rmi -f %%i
+  )
+  call:print "### removed service images ###"
+  exit /b %ErrorLevel%

--- a/scripts/testing/setup_private_registry.bat
+++ b/scripts/testing/setup_private_registry.bat
@@ -1,0 +1,87 @@
+@echo off
+setlocal
+
+:: Create self-signed certificate.
+call:mkdirp %~dp0certs
+call openssl req ^
+  -newkey rsa:2048 ^
+  -nodes ^
+  -x509 ^
+  -days 365 ^
+  -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=127.0.0.1" ^
+  -keyout %~dp0certs\registry_auth.key ^
+  -out %~dp0certs\registry_auth.crt
+if %ErrorLevel% neq 0 (
+  call:print "Failed to generate self-signed certificate."
+  exit /b %ErrorLevel%
+)
+
+:: Generate random credentials.
+call:mkdirp %~dp0auth
+call docker run ^
+  --rm ^
+  --entrypoint htpasswd ^
+  registry:2 ^
+  -Bbn testuser testpwd ^
+  > %~dp0auth\htpasswd
+if %ErrorLevel% neq 0 (
+  call:print "Failed to generate random credentials."
+  exit /b %ErrorLevel%
+)
+
+:: Start an ephemeral Docker registry in a container.
+::  --rm ^
+@echo on
+call docker run ^
+  -d ^
+  --name private_registry ^
+  -p 15000:5000 ^
+  -v %~dp0auth:/auth ^
+  -e "REGISTRY_AUTH=htpasswd" ^
+  -e "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm" ^
+  -e "REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd" ^
+  -v %~dp0certs:/certs ^
+  -e "REGISTRY_HTTP_TLS_CERTIFICATE=/certs/registry_auth.crt" ^
+  -e "REGISTRY_HTTP_TLS_KEY=/certs/registry_auth.key" ^
+  registry:2
+if %ErrorLevel% neq 0 (
+  call:print "Failed to create ephemeral Docker registry."
+  exit /b %ErrorLevel%
+)
+
+:: Wait until the container is responsive (*crosses fingers*).
+timeout /t 5
+
+:: Point our Docker Daemon to this ephemeral registry.
+call docker login -u testuser -p testpwd 127.0.0.1:15000
+if %ErrorLevel% neq 0 (
+  call:print "Failed to log in to ephemeral Docker registry."
+  exit /b %ErrorLevel%
+)
+
+:: Build a few private images.
+for /L %%i in (1,1,3) do (
+  call docker build ^
+    -t tftest-service ^
+    %~dp0 ^
+    -f %~dp0Dockerfile_v%%i
+  call docker tag ^
+    tftest-service ^
+    127.0.0.1:15000/tftest-service:v%%i
+  call docker push ^
+    127.0.0.1:15000/tftest-service:v%%i
+)
+
+exit /b %ErrorLevel%
+
+
+:print
+  echo %~1
+  exit /b 0
+
+
+:mkdirp
+  if not exist %~1\nul (
+    mkdir %~1
+  )
+  exit /b %ErrorLevel%


### PR DESCRIPTION
After discussion with @mavogel in issue #52, I prepared some batch files to run the acceptance tests on Windows.

I manage to run the test suite using these batch files.  However, the tests fail because they reference Unix sockets, so I guess there is more work to do :-)

**Edit**: ~~I'm not super familiar with AppVeyor, but maybe I can give that a try tomorrow.~~ I submitted PR #59 with a AppVeyor support.  Assuming that gets merged, I could have that run these scripts.

**Note**: `docker`, `go` and `openssl` must be in your `%PATH%` for these scripts to work.  I run the tests using [cmder](http://cmder.net/), which seems to provide `openssl` out of the box.

**Note**: the first time you mount a volume inside a container, Docker for Windows will prompt you for a request to allow the mount.  I'm not sure what this will do when you try to run it under AppVeyor.