### PR TITLE
Add tentative AppVeyor configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,19 @@
+version: {build}
+image: Visual Studio 2017
+
+environment:
+  GOPATH: C:\gopath
+
+clone_folder: C:\gopath\src\github.com\terraform-providers\terraform-provider-docker
+
+install:
+  - echo %PATH%
+  - go version
+  - go env
+  - docker version
+  - openssl version
+  - pwd
+
+build_script:
+  - go get github.com/hashicorp/terraform/plugin
+  - go install


### PR DESCRIPTION
By request from @mavogel :-)

I think you'll need to set up AppVeyor on this repository in order to trigger your first build.

**Note**: this build does not run acceptance tests.  There is preliminary support for that in #58 and probably more work to do since they don't pass on Windows (yet).

**Edit**: I tested this on my personal AppVeyor account by creating a dummy PR in my fork.  Here is an example build output: [AndreLouisCaron/terraform-provider-docker build 1.0.12](https://ci.appveyor.com/project/AndreLouisCaron/terraform-provider-docker/build/1.0.12).