### PR TITLE
build/docker-in-docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ before_install:
 - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 - sudo apt-get update
-- sudo apt-get -y install docker-ce=17.09.1~ce-0~ubuntu # latest stable without the bug: https://github.com/moby/moby/issues/36661
-- docker version
+- sudo apt-get -y install docker-ce
+- echo "OUTER Docker version" && docker version
 
 install:
 # This script is used by the Travis build to install a cookie for
@@ -20,16 +20,11 @@ install:
 # See: https://github.com/golang/go/issues/12933
 - bash scripts/gogetcookie.sh
 - go get github.com/kardianos/govendor
-- sudo sed 's/DOCKER_OPTS="/DOCKER_OPTS="--insecure-registry=127.0.0.1:15000 /g' -i /etc/default/docker
 - sudo cat /etc/default/docker
 - sudo service docker restart
 
 script:
-- make test
-- make testacc
-- make vendor-status
-- make vet
-- make website-test
+- bash docker_in_docker.sh
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
 - sudo service docker restart
 
 script:
-- bash docker_in_docker.sh
+- bash scripts/docker_in_docker.sh
 
 branches:
   only:

--- a/scripts/docker_in_docker.sh
+++ b/scripts/docker_in_docker.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+IMAGE_NAME="mavogel/tf-test-docker:17.09-dind"
+CONTAINER_NAME="tf-test-docker"
+PROVIDER_NAME="terraform-provider-docker"
+
+echo "#### Starting '$CONTAINER_NAME'"
+# Optionally not mounting the code
+#docker run --privileged --name "$CONTAINER_NAME" --rm -d "$IMAGE_NAME"
+docker run --privileged --name "$CONTAINER_NAME" --rm -v "$GOPATH"/src/github.com/terraform-providers:/go/src/github.com/terraform-providers -d "$IMAGE_NAME" --storage-driver=overlay
+
+# NOTE: although it is in the Dockerfile a `which openssl` does not find the binary
+echo "#### Treating openssl"
+docker exec -it "$CONTAINER_NAME" sh -c "cd /go/src/github.com/terraform-providers/${PROVIDER_NAME} && apk del openssl && apk add --no-cache openssl"
+
+echo "#### INNER Docker version"
+docker exec -it "$CONTAINER_NAME" sh -c "cd /go/src/github.com/terraform-providers/${PROVIDER_NAME} && docker version"
+
+echo "#### Running tests..."
+# Optionally checking the code out within the container instead of mounting it
+#docker exec -it "$CONTAINER_NAME" sh -c "git clone https://github.com/terraform-providers/${PROVIDER_NAME}.git --depth=1 /go/src/github.com/terraform-providers/${PROVIDER_NAME}"
+COMMANDS=(
+  "test" 
+  "testacc" 
+  "vendor-status" 
+  "vet"
+  #"website-test" # some wget problems atm...
+)
+for cmd in "${COMMANDS[@]}";
+  do docker exec -it "$CONTAINER_NAME" sh -c "cd /go/src/github.com/terraform-providers/${PROVIDER_NAME} && make $cmd"
+done
+
+echo "#### Stopping '$CONTAINER_NAME'"
+docker stop "$CONTAINER_NAME"

--- a/scripts/docker_in_docker.sh
+++ b/scripts/docker_in_docker.sh
@@ -5,26 +5,22 @@ CONTAINER_NAME="tf-test-docker"
 PROVIDER_NAME="terraform-provider-docker"
 
 echo "#### Starting '$CONTAINER_NAME'"
-# Optionally not mounting the code
-#docker run --privileged --name "$CONTAINER_NAME" --rm -d "$IMAGE_NAME"
 docker run --privileged --name "$CONTAINER_NAME" --rm -v "$GOPATH"/src/github.com/terraform-providers:/go/src/github.com/terraform-providers -d "$IMAGE_NAME" --storage-driver=overlay
 
 # NOTE: although it is in the Dockerfile a `which openssl` does not find the binary
-echo "#### Treating openssl"
+echo "#### Fixing openssl"
 docker exec -it "$CONTAINER_NAME" sh -c "cd /go/src/github.com/terraform-providers/${PROVIDER_NAME} && apk del openssl && apk add --no-cache openssl"
 
 echo "#### INNER Docker version"
 docker exec -it "$CONTAINER_NAME" sh -c "cd /go/src/github.com/terraform-providers/${PROVIDER_NAME} && docker version"
 
 echo "#### Running tests..."
-# Optionally checking the code out within the container instead of mounting it
-#docker exec -it "$CONTAINER_NAME" sh -c "git clone https://github.com/terraform-providers/${PROVIDER_NAME}.git --depth=1 /go/src/github.com/terraform-providers/${PROVIDER_NAME}"
 COMMANDS=(
   "test" 
   "testacc" 
   "vendor-status" 
   "vet"
-  #"website-test" # some wget problems atm...
+  "website-test"
 )
 for cmd in "${COMMANDS[@]}";
   do docker exec -it "$CONTAINER_NAME" sh -c "cd /go/src/github.com/terraform-providers/${PROVIDER_NAME} && make $cmd"


### PR DESCRIPTION
- PoC for running the test with `docker-in-docker` based on https://hub.docker.com/_/docker/
- create temporary Docker images: `https://hub.docker.com/r/mavogel/tf-test-docker`
- Benefit will be to be independent of the Docker version of the `AMI`of the CI infra