### PR TITLE
[fix-documentation-ports] only one port has to be set

### DIFF
--- a/website/docs/r/container.html.markdown
+++ b/website/docs/r/container.html.markdown
@@ -121,11 +121,13 @@ resource "docker_container" "ubuntu" {
 the port mappings of the container. Each `ports` block supports
 the following:
 
-* `internal` - (Required, int) Port within the container.
-* `external` - (Required, int) Port exposed out of the container.
+* `internal` - (Optional, int) Port within the container.
+* `external` - (Optional, int) Port exposed out of the container.
 * `ip` - (Optional, string) IP address/mask that can access this port.
 * `protocol` - (Optional, string) Protocol that can be used over this port,
   defaults to TCP.
+
+One of `internal` or `external` must be set.
 
 <a id="extra_hosts"></a>
 ### Extra Hosts


### PR DESCRIPTION
This PR update the doc about ports which are not both required. It's relative to the issue #8 which could be closed.