### PR TITLE
Fix/cert material

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 BUG FIXES
 * Fixes connection via TLS to docker host with file contents [GH-86]
+* Skips TLS verification if `ca_material` is not set [GH-14]
 
 ## 1.0.1 (August 06, 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## 1.0.2 (Unreleased)
+
+BUG FIXES
+* Fixes connection via TLS to docker host with file contents [GH-86]
+
 ## 1.0.1 (August 06, 2018)
 
 BUG FIXES

--- a/docker/config.go
+++ b/docker/config.go
@@ -29,7 +29,7 @@ type Config struct {
 }
 
 // buildHTTPClientFromBytes builds the http client from bytes (content of the files)
-func buildHTTPClientFromBytes(certPEMBlock, keyPEMBlock, caPEMCert []byte) (*http.Client, error) {
+func buildHTTPClientFromBytes(caPEMCert, certPEMBlock, keyPEMBlock []byte) (*http.Client, error) {
 	tlsConfig := &tls.Config{}
 	if certPEMBlock != nil && keyPEMBlock != nil {
 		tlsCert, err := tls.X509KeyPair(certPEMBlock, keyPEMBlock)
@@ -39,7 +39,7 @@ func buildHTTPClientFromBytes(certPEMBlock, keyPEMBlock, caPEMCert []byte) (*htt
 		tlsConfig.Certificates = []tls.Certificate{tlsCert}
 	}
 
-	if caPEMCert == nil {
+	if caPEMCert == nil || len(caPEMCert) == 0 {
 		tlsConfig.InsecureSkipVerify = true
 	} else {
 		caPool := x509.NewCertPool()
@@ -83,16 +83,16 @@ func defaultPooledTransport() *http.Transport {
 
 // NewClient returns a new Docker client.
 func (c *Config) NewClient() (*client.Client, error) {
-	if c.Ca != "" || c.Cert != "" || c.Key != "" {
-		if c.Ca == "" || c.Cert == "" || c.Key == "" {
-			return nil, fmt.Errorf("ca_material, cert_material, and key_material must be specified")
+	if c.Cert != "" || c.Key != "" {
+		if c.Cert == "" || c.Key == "" {
+			return nil, fmt.Errorf("cert_material, and key_material must be specified")
 		}
 
 		if c.CertPath != "" {
 			return nil, fmt.Errorf("cert_path must not be specified")
 		}
 
-		httpClient, err := buildHTTPClientFromBytes([]byte(c.Cert), []byte(c.Key), []byte(c.Ca))
+		httpClient, err := buildHTTPClientFromBytes([]byte(c.Ca), []byte(c.Cert), []byte(c.Key))
 		if err != nil {
 			return nil, err
 		}

--- a/docker/config.go
+++ b/docker/config.go
@@ -1,9 +1,16 @@
 package docker
 
 import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
 	"fmt"
+	"net"
+	"net/http"
 	"path/filepath"
+	"runtime"
 	"strings"
+	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
@@ -21,6 +28,59 @@ type Config struct {
 	CertPath string
 }
 
+// buildHTTPClientFromBytes builds the http client from bytes (content of the files)
+func buildHTTPClientFromBytes(certPEMBlock, keyPEMBlock, caPEMCert []byte) (*http.Client, error) {
+	tlsConfig := &tls.Config{}
+	if certPEMBlock != nil && keyPEMBlock != nil {
+		tlsCert, err := tls.X509KeyPair(certPEMBlock, keyPEMBlock)
+		if err != nil {
+			return nil, err
+		}
+		tlsConfig.Certificates = []tls.Certificate{tlsCert}
+	}
+
+	if caPEMCert == nil {
+		tlsConfig.InsecureSkipVerify = true
+	} else {
+		caPool := x509.NewCertPool()
+		if !caPool.AppendCertsFromPEM(caPEMCert) {
+			return nil, errors.New("Could not add RootCA pem")
+		}
+		tlsConfig.RootCAs = caPool
+	}
+
+	tr := defaultTransport()
+	tr.TLSClientConfig = tlsConfig
+	return &http.Client{Transport: tr}, nil
+}
+
+// defaultTransport returns a new http.Transport with similar default values to
+// http.DefaultTransport, but with idle connections and keepalives disabled.
+func defaultTransport() *http.Transport {
+	transport := defaultPooledTransport()
+	transport.DisableKeepAlives = true
+	transport.MaxIdleConnsPerHost = -1
+	return transport
+}
+
+// defaultPooledTransport returns a new http.Transport with similar default
+// values to http.DefaultTransport.
+func defaultPooledTransport() *http.Transport {
+	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		MaxIdleConnsPerHost:   runtime.GOMAXPROCS(0) + 1,
+	}
+	return transport
+}
+
 // NewClient returns a new Docker client.
 func (c *Config) NewClient() (*client.Client, error) {
 	if c.Ca != "" || c.Cert != "" || c.Key != "" {
@@ -32,9 +92,16 @@ func (c *Config) NewClient() (*client.Client, error) {
 			return nil, fmt.Errorf("cert_path must not be specified")
 		}
 
+		httpClient, err := buildHTTPClientFromBytes([]byte(c.Cert), []byte(c.Key), []byte(c.Ca))
+		if err != nil {
+			return nil, err
+		}
+
+		// Note: don't change the order here, because the custom client
+		// needs to be set first them we overwrite the other options: host, version
 		return client.NewClientWithOpts(
+			client.WithHTTPClient(httpClient),
 			client.WithHost(c.Host),
-			client.WithTLSClientConfig(c.Ca, c.Cert, c.Key),
 			client.WithVersion(apiVersion),
 		)
 	}

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -91,6 +91,25 @@ and paste it into `~/.docker/config.json`:
 }
 ```
 
+## Certificate information
+
+Specify certificate information either with a directory or
+directly with the content of the files for connecting to the Docker host via TLS.
+
+```hcl
+provider "docker" {
+  host    = "tcp://your-host-ip:2376/"
+
+  # -> specify either
+  cert_path = "${pathexpand("~/.docker")}"
+
+  # -> or the following
+  ca_material = "${file(pathexpand("~/.docker/ca.pem"))}"
+  cert_material = "${file(pathexpand("~/.docker/cert.pem"))}"
+  key_material = "${file(pathexpand("~/.docker/key.pem"))}"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -104,7 +104,7 @@ provider "docker" {
   cert_path = "${pathexpand("~/.docker")}"
 
   # -> or the following
-  ca_material = "${file(pathexpand("~/.docker/ca.pem"))}"
+  ca_material = "${file(pathexpand("~/.docker/ca.pem"))}" # this can be omitted
   cert_material = "${file(pathexpand("~/.docker/cert.pem"))}"
   key_material = "${file(pathexpand("~/.docker/key.pem"))}"
 }
@@ -118,11 +118,12 @@ The following arguments are supported:
   blank, the `DOCKER_HOST` environment variable will also be read.
 
 * `cert_path` - (Optional) Path to a directory with certificate information
-  for connecting to the Docker host via TLS. If this is blank, the
-  `DOCKER_CERT_PATH` will also be checked.
+  for connecting to the Docker host via TLS. It is expected that the 3 files `{ca, cert, key}.pem` 
+  are present in the path. If the path is blank, the `DOCKER_CERT_PATH` will also be checked.
 
 * `ca_material`, `cert_material`, `key_material`, - (Optional) Content of `ca.pem`, `cert.pem`, and `key.pem` files
-  for TLS authentication. Cannot be used together with `cert_path`.
+  for TLS authentication. Cannot be used together with `cert_path`. If `ca_material` is omitted
+  the client does not check the servers certificate chain and host name.
 
 * `registry_auth` - (Optional) A block specifying the credentials for a target
   v2 Docker registry.


### PR DESCRIPTION
- fixes connection via TLS to docker host with file contents of #86
- adds documentation for connecting via TLS to docker host
- fixes skip of TLS verification if `ca_material` is not set. Closes #14 

I verified locally as follows:
```hcl
provider "docker" {
  version = "~> 1.0.2"
  host    = "tcp://${var.aws_ip}:2376/"

  # -> either
  cert_path = "${pathexpand("~/.docker")}"

  # -> or the following work :)
  ca_material = "${file(pathexpand("~/.docker/ca.pem"))}" # this can be omitted. Check docs
  cert_material = "${file(pathexpand("~/.docker/cert.pem"))}"
  key_material = "${file(pathexpand("~/.docker/key.pem"))}"
}
```