### PR TITLE
Add labels to support docker stacks

### DIFF
--- a/docker/resource_docker_container.go
+++ b/docker/resource_docker_container.go
@@ -398,9 +398,10 @@ func resourceDockerContainer() *schema.Resource {
 			},
 
 			"network_mode": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateStringMatchesPattern(`^(bridge|host|none|container:.+|service:.+)$`),
 			},
 
 			"networks": &schema.Schema{

--- a/docker/resource_docker_container_funcs.go
+++ b/docker/resource_docker_container_funcs.go
@@ -211,6 +211,10 @@ func resourceDockerContainerCreate(d *schema.ResourceData, meta interface{}) err
 			endpointConfig.Aliases = stringSetToStringSlice(v.(*schema.Set))
 		}
 
+		if err := client.NetworkDisconnect(context.Background(), "bridge", retContainer.ID, false); err != nil {
+			return fmt.Errorf("Unable to disconnect the default network: %s", err)
+		}
+
 		for _, rawNetwork := range v.(*schema.Set).List() {
 			networkID := rawNetwork.(string)
 			if err := client.NetworkConnect(context.Background(), networkID, retContainer.ID, endpointConfig); err != nil {

--- a/docker/resource_docker_network.go
+++ b/docker/resource_docker_network.go
@@ -22,6 +22,12 @@ func resourceDockerNetwork() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"labels": &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"check_duplicate": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -46,6 +52,24 @@ func resourceDockerNetwork() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Computed: true,
+				ForceNew: true,
+			},
+
+			"attachable": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"ingress": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"ipv6": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
 				ForceNew: true,
 			},
 

--- a/docker/resource_docker_network_funcs.go
+++ b/docker/resource_docker_network_funcs.go
@@ -17,6 +17,9 @@ func resourceDockerNetworkCreate(d *schema.ResourceData, meta interface{}) error
 	client := meta.(*ProviderConfig).DockerClient
 
 	createOpts := types.NetworkCreate{}
+	if v, ok := d.GetOk("labels"); ok {
+		createOpts.Labels = mapTypeMapValsToString(v.(map[string]interface{}))
+	}
 	if v, ok := d.GetOk("check_duplicate"); ok {
 		createOpts.CheckDuplicate = v.(bool)
 	}
@@ -28,6 +31,15 @@ func resourceDockerNetworkCreate(d *schema.ResourceData, meta interface{}) error
 	}
 	if v, ok := d.GetOk("internal"); ok {
 		createOpts.Internal = v.(bool)
+	}
+	if v, ok := d.GetOk("attachable"); ok {
+		createOpts.Attachable = v.(bool)
+	}
+	if v, ok := d.GetOk("ingress"); ok {
+		createOpts.Ingress = v.(bool)
+	}
+	if v, ok := d.GetOk("ipv6"); ok {
+		createOpts.EnableIPv6 = v.(bool)
 	}
 
 	ipamOpts := &network.IPAM{}
@@ -128,6 +140,9 @@ func resourceDockerNetworkReadRefreshFunc(
 		log.Printf("[DEBUG] Docker network inspect: %s", jsonObj)
 
 		d.Set("internal", retNetwork.Internal)
+		d.Set("attachable", retNetwork.Attachable)
+		d.Set("ingress", retNetwork.Ingress)
+		d.Set("ipv6", retNetwork.EnableIPv6)
 		d.Set("driver", retNetwork.Driver)
 		d.Set("scope", retNetwork.Scope)
 		if retNetwork.Scope == "overlay" {

--- a/docker/resource_docker_network_test.go
+++ b/docker/resource_docker_network_test.go
@@ -95,7 +95,7 @@ func testAccNetworkInternal(network *types.NetworkResource, internal bool) resou
 const testAccDockerNetworkInternalConfig = `
 resource "docker_network" "foobar" {
   name = "foobar"
-  internal = "true"
+  internal = true
 }
 `
 
@@ -117,9 +117,9 @@ func TestAccDockerNetwork_attachable(t *testing.T) {
 	})
 }
 
-func testAccNetworkAttachable(network *types.NetworkResource, internal bool) resource.TestCheckFunc {
+func testAccNetworkAttachable(network *types.NetworkResource, attachable bool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if network.Internal != internal {
+		if network.Attachable != attachable {
 			return fmt.Errorf("Bad value for attribute 'attachable': %t", network.Attachable)
 		}
 		return nil
@@ -129,75 +129,7 @@ func testAccNetworkAttachable(network *types.NetworkResource, internal bool) res
 const testAccDockerNetworkAttachableConfig = `
 resource "docker_network" "foobar" {
   name = "foobar"
-  attachable = "true"
-}
-`
-
-func TestAccDockerNetwork_ingress(t *testing.T) {
-	var n types.NetworkResource
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccDockerNetworkIngressConfig,
-				Check: resource.ComposeTestCheckFunc(
-					testAccNetwork("docker_network.foobar", &n),
-					testAccNetworkIngress(&n, true),
-				),
-			},
-		},
-	})
-}
-
-func testAccNetworkIngress(network *types.NetworkResource, internal bool) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if network.Internal != internal {
-			return fmt.Errorf("Bad value for attribute 'ingress': %t", network.Ingress)
-		}
-		return nil
-	}
-}
-
-const testAccDockerNetworkIngressConfig = `
-resource "docker_network" "foobar" {
-  name = "foobar"
-  ingress = "true"
-}
-`
-
-func TestAccDockerNetwork_ipv6(t *testing.T) {
-	var n types.NetworkResource
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccDockerNetworkIpv6Config,
-				Check: resource.ComposeTestCheckFunc(
-					testAccNetwork("docker_network.foobar", &n),
-					testAccNetworkIpv6(&n, true),
-				),
-			},
-		},
-	})
-}
-
-func testAccNetworkIpv6(network *types.NetworkResource, internal bool) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if network.Internal != internal {
-			return fmt.Errorf("Bad value for attribute 'ipv6': %t", network.EnableIPv6)
-		}
-		return nil
-	}
-}
-
-const testAccDockerNetworkIpv6Config = `
-resource "docker_network" "foobar" {
-  name = "foobar"
-  ipv6 = "true"
+  attachable = true
 }
 `
 

--- a/docker/resource_docker_network_test.go
+++ b/docker/resource_docker_network_test.go
@@ -98,3 +98,143 @@ resource "docker_network" "foobar" {
   internal = "true"
 }
 `
+
+func TestAccDockerNetwork_attachable(t *testing.T) {
+	var n types.NetworkResource
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDockerNetworkAttachableConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccNetwork("docker_network.foobar", &n),
+					testAccNetworkAttachable(&n, true),
+				),
+			},
+		},
+	})
+}
+
+func testAccNetworkAttachable(network *types.NetworkResource, internal bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if network.Internal != internal {
+			return fmt.Errorf("Bad value for attribute 'attachable': %t", network.Attachable)
+		}
+		return nil
+	}
+}
+
+const testAccDockerNetworkAttachableConfig = `
+resource "docker_network" "foobar" {
+  name = "foobar"
+  attachable = "true"
+}
+`
+
+func TestAccDockerNetwork_ingress(t *testing.T) {
+	var n types.NetworkResource
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDockerNetworkIngressConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccNetwork("docker_network.foobar", &n),
+					testAccNetworkIngress(&n, true),
+				),
+			},
+		},
+	})
+}
+
+func testAccNetworkIngress(network *types.NetworkResource, internal bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if network.Internal != internal {
+			return fmt.Errorf("Bad value for attribute 'ingress': %t", network.Ingress)
+		}
+		return nil
+	}
+}
+
+const testAccDockerNetworkIngressConfig = `
+resource "docker_network" "foobar" {
+  name = "foobar"
+  ingress = "true"
+}
+`
+
+func TestAccDockerNetwork_ipv6(t *testing.T) {
+	var n types.NetworkResource
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDockerNetworkIpv6Config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccNetwork("docker_network.foobar", &n),
+					testAccNetworkIpv6(&n, true),
+				),
+			},
+		},
+	})
+}
+
+func testAccNetworkIpv6(network *types.NetworkResource, internal bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if network.Internal != internal {
+			return fmt.Errorf("Bad value for attribute 'ipv6': %t", network.EnableIPv6)
+		}
+		return nil
+	}
+}
+
+const testAccDockerNetworkIpv6Config = `
+resource "docker_network" "foobar" {
+  name = "foobar"
+  ipv6 = "true"
+}
+`
+
+func TestAccDockerNetwork_labels(t *testing.T) {
+	var n types.NetworkResource
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDockerNetworkLabelsConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccNetwork("docker_network.foobar", &n),
+					testAccNetworkLabel(&n, "com.docker.compose.network", "foobar"),
+					testAccNetworkLabel(&n, "com.docker.compose.project", "test"),
+				),
+			},
+		},
+	})
+}
+
+func testAccNetworkLabel(network *types.NetworkResource, name string, value string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if network.Labels[name] != value {
+			return fmt.Errorf("Bad value for label '%s': %s", name, network.Labels[name])
+		}
+		return nil
+	}
+}
+
+const testAccDockerNetworkLabelsConfig = `
+resource "docker_network" "foobar" {
+  name = "test_foobar"
+  labels {
+    "com.docker.compose.network" = "foobar"
+    "com.docker.compose.project" = "test"
+  }
+}
+`

--- a/docker/resource_docker_secret.go
+++ b/docker/resource_docker_secret.go
@@ -31,6 +31,12 @@ func resourceDockerSecret() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validateStringIsBase64Encoded(),
 			},
+
+			"labels": &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -44,6 +50,10 @@ func resourceDockerSecretCreate(d *schema.ResourceData, meta interface{}) error 
 			Name: d.Get("name").(string),
 		},
 		Data: data,
+	}
+
+	if v, ok := d.GetOk("labels"); ok {
+		secretSpec.Annotations.Labels = mapTypeMapValsToString(v.(map[string]interface{}))
 	}
 
 	secret, err := client.SecretCreate(context.Background(), secretSpec)

--- a/docker/resource_docker_secret_test.go
+++ b/docker/resource_docker_secret_test.go
@@ -30,6 +30,7 @@ func TestAccDockerSecret_basic(t *testing.T) {
 		},
 	})
 }
+
 func TestAccDockerSecret_basicUpdatable(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -66,6 +67,32 @@ func TestAccDockerSecret_basicUpdatable(t *testing.T) {
 				`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("docker_secret.foo", "data", "U3VuIDI1IE1hciAyMDE4IDE0OjUzOjIxIENFU1QK"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDockerSecret_labels(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckDockerSecretDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: `
+				resource "docker_secret" "foo" {
+					name = "foo-secret"
+					data = "Ymxhc2RzYmxhYmxhMTI0ZHNkd2VzZA=="
+					labels {
+						"test1" = "foo"
+						"test2" = "bar"
+					}
+				}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("docker_secret.foo", "labels.test1", "foo"),
+					resource.TestCheckResourceAttr("docker_secret.foo", "labels.test2", "bar"),
 				),
 			},
 		},

--- a/docker/resource_docker_volume.go
+++ b/docker/resource_docker_volume.go
@@ -25,6 +25,11 @@ func resourceDockerVolume() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
+			"labels": &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+			},
 			"driver": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -52,6 +57,9 @@ func resourceDockerVolumeCreate(d *schema.ResourceData, meta interface{}) error 
 
 	if v, ok := d.GetOk("name"); ok {
 		createOpts.Name = v.(string)
+	}
+	if v, ok := d.GetOk("labels"); ok {
+		createOpts.Labels = mapTypeMapValsToString(v.(map[string]interface{}))
 	}
 	if v, ok := d.GetOk("driver"); ok {
 		createOpts.Driver = v.(string)

--- a/website/docs/r/network.html.markdown
+++ b/website/docs/r/network.html.markdown
@@ -29,6 +29,7 @@ resource "docker_network" "private_network" {
 The following arguments are supported:
 
 * `name` - (Required, string) The name of the Docker network.
+* `labels` - (Optional, map of string/string key/value pairs) User-defined key/value metadata.
 * `check_duplicate` - (Optional, boolean) Requests daemon to check for networks
   with same name.
 * `driver` - (Optional, string) Name of the network driver to use. Defaults to

--- a/website/docs/r/network.html.markdown
+++ b/website/docs/r/network.html.markdown
@@ -38,6 +38,12 @@ The following arguments are supported:
   the drivers.
 * `internal` - (Optional, boolean) Restrict external access to the network.
   Defaults to `false`.
+* `attachable` - (Optional, boolean) Enable manual container attachment to the network.
+  Defaults to `false`.
+* `ingress` - (Optional, boolean) Create swarm routing-mesh network.
+  Defaults to `false`.
+* `ipv6` - (Optional, boolean) Enable IPv6 networking.
+  Defaults to `false`.
 * `ipam_driver` - (Optional, string) Driver used by the custom IP scheme of the
   network.
 * `ipam_config` - (Optional, block) See [IPAM config](#ipam_config) below for

--- a/website/docs/r/secret.html.markdown
+++ b/website/docs/r/secret.html.markdown
@@ -55,7 +55,7 @@ The following arguments are supported:
 
 * `name` - (Required, string) The name of the Docker secret.
 * `data` - (Required, string) The base64 encoded data of the secret.
-
+* `labels` - (Optional, map of string/string key/value pairs) User-defined key/value metadata.
 
 ## Attributes Reference
 

--- a/website/docs/r/volume.html.markdown
+++ b/website/docs/r/volume.html.markdown
@@ -30,6 +30,7 @@ The following arguments are supported:
 
 * `name` - (Optional, string) The name of the Docker volume (generated if not
   provided).
+* `labels` - (Optional, map of string/string key/value pairs) User-defined key/value metadata.
 * `driver` - (Optional, string) Driver type for the volume (defaults to local).
 * `driver_opts` - (Optional, map of strings) Options specific to the driver.
 


### PR DESCRIPTION
This PR adds the missing labels to `docker_network` and `docker_volume` resources allowing to simulate docker-compose stacks. It can be used to support docker UCP/swarm collections.

Improvements:
- add labels to `docker_network` and these new flags: attachable, ingress, ipv6
- add labels to `docker_volume`
- add labels to `docker_secret`
- fix bug with default bridge network and custom user networks (`network_mode` + `networks`). Network aliases are working now (`network_alias`)

I use this plan to test it with portainer which have the capability to show docker stacks (swarm + docker-compose):

```
variable "docker_project" {
  default = "test"
}

resource "docker_network" "default" {
  name       = "${var.docker_project}_default"
  attachable = true

  labels {
    "com.docker.compose.network" = "default"
    "com.docker.compose.project" = "${var.docker_project}"
  }
}

resource "docker_volume" "portainer" {
  name = "${var.docker_project}_portainer"

  labels {
    "com.docker.compose.project" = "${var.docker_project}"
    "com.docker.compose.volume"  = "portainer"
  }
}

resource "docker_container" "portainer" {
  count = 1

  image   = "bhuisgen/alpine-portainer:prod"
  name    = "${var.docker_project}_portainer_${count.index + 1}"
  restart = "unless-stopped"

  labels {
    "com.docker.compose.container-number" = "${count.index + 1}"
    "com.docker.compose.project"          = "${var.docker_project}"
    "com.docker.compose.service"          = "portainer"
    "com.docker.compose.oneoff"           = "False"
    "com.docker.compose.version"          = "1.22.0"
  }

  network_mode  = "bridge"
  networks      = ["${docker_network.default.id}"]
  network_alias = ["portainer"]

  ports {
    ip       = "169.254.0.1"
    external = "8080"
    internal = "9000"
  }

  volumes {
    host_path      = "/etc/localtime"
    container_path = "/etc/localtime"
    read_only      = true
  }

  volumes {
    volume_name    = "${docker_volume.portainer.name}"
    container_path = "/var/lib/portainer"
  }

  volumes {
    host_path      = "/var/run/docker.sock"
    container_path = "/var/run/docker.sock"
  }

  env = [
    "ENV=local",
    "PORTAINER_TEMPLATE=generic",
  ]

  log_driver = "syslog"

  log_opts {
    "tag" = "{{.Name}}/{{.ID}}"
  }

  must_run = true
}
```
