### PR TITLE
Add the docker container start flag

### DIFF
--- a/docker/resource_docker_container.go
+++ b/docker/resource_docker_container.go
@@ -18,6 +18,12 @@ func resourceDockerContainer() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"start": &schema.Schema{
+				Type:     schema.TypeBool,
+				Default:  true,
+				Optional: true,
+			},
+
 			// Indicates whether the container must be running.
 			//
 			// An assumption is made that configured containers

--- a/docker/resource_docker_container_funcs.go
+++ b/docker/resource_docker_container_funcs.go
@@ -262,10 +262,12 @@ func resourceDockerContainerCreate(d *schema.ResourceData, meta interface{}) err
 		}
 	}
 
-	creationTime = time.Now()
-	options := types.ContainerStartOptions{}
-	if err := client.ContainerStart(context.Background(), retContainer.ID, options); err != nil {
-		return fmt.Errorf("Unable to start container: %s", err)
+	if d.Get("start").(bool) {
+		creationTime = time.Now()
+		options := types.ContainerStartOptions{}
+		if err := client.ContainerStart(context.Background(), retContainer.ID, options); err != nil {
+			return fmt.Errorf("Unable to start container: %s", err)
+		}
 	}
 
 	return resourceDockerContainerRead(d, meta)

--- a/website/docs/r/container.html.markdown
+++ b/website/docs/r/container.html.markdown
@@ -65,6 +65,8 @@ data is stored in them. See [the docker documentation][linkdoc] for more details
   one of "no", "on-failure", "always", "unless-stopped".
 * `max_retry_count` - (Optional, int) The maximum amount of times to an attempt
   a restart when `restart` is set to "on-failure"
+* `start` - (Optional, bool) If true, then the Docker container will be
+  started after creation. If false, then the container is only created.
 * `must_run` - (Optional, bool) If true, then the Docker container will be
   kept running. If false, then as long as the container exists, Terraform
   assumes it is successful.


### PR DESCRIPTION
This PR allows to create only a container without starting it after creation (it will start at next reboot depending of the restart policy).

```
resource "docker_image" "foo" {
	name = "nginx:latest"
}

resource "docker_container" "foo" {
	name = "tf-test"
	image = "${docker_image.foo.latest}"
	start = false
        must_run = false
}
```