### PR TITLE
fixes ports on containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 IMPROVEMENTS
 * Add support for running tests on Windows [GH-54] and ([#90](https://github.com/terraform-providers/terraform-provider-docker/pull/90))
+
+BUG FIXES
 * Fixes issue with internal and external ports on containers [GH-8] and ([#89](https://github.com/terraform-providers/terraform-provider-docker/pull/90))
+* Fixes `tfstate` having correct external port for containers [GH-73]
 
 ## 1.0.2 (September 27, 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS
 * Add support for running tests on Windows [GH-54] and ([#90](https://github.com/terraform-providers/terraform-provider-docker/pull/90))
+* Fixes issue with internal and external ports on containers [GH-8] and ([#89](https://github.com/terraform-providers/terraform-provider-docker/pull/90))
 
 ## 1.0.2 (September 27, 2018)
 

--- a/docker/resource_docker_container.go
+++ b/docker/resource_docker_container.go
@@ -206,11 +206,13 @@ func resourceDockerContainer() *schema.Resource {
 						"external": &schema.Schema{
 							Type:     schema.TypeInt,
 							Optional: true,
+							Computed: true,
 							ForceNew: true,
 						},
 
 						"ip": &schema.Schema{
 							Type:     schema.TypeString,
+							Default:  "0.0.0.0",
 							Optional: true,
 							ForceNew: true,
 						},

--- a/docker/resource_docker_container.go
+++ b/docker/resource_docker_container.go
@@ -205,8 +205,8 @@ func resourceDockerContainer() *schema.Resource {
 
 						"external": &schema.Schema{
 							Type:     schema.TypeInt,
+							Default:  "32678",
 							Optional: true,
-							Computed: true,
 							ForceNew: true,
 						},
 

--- a/docker/resource_docker_container_funcs.go
+++ b/docker/resource_docker_container_funcs.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"context"
+	"math/rand"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
@@ -16,7 +18,6 @@ import (
 	"github.com/docker/go-connections/nat"
 	"github.com/docker/go-units"
 	"github.com/hashicorp/terraform/helper/schema"
-	"math/rand"
 )
 
 var (
@@ -321,10 +322,13 @@ func resourceDockerContainerRead(d *schema.ResourceData, meta interface{}) error
 		d.Set("bridge", container.NetworkSettings.Bridge)
 	}
 
+	// TODO read ports here as well
+
 	return nil
 }
 
 func resourceDockerContainerUpdate(d *schema.ResourceData, meta interface{}) error {
+	// TODO call resourceDockerContainerRead here
 	return nil
 }
 
@@ -353,6 +357,8 @@ func resourceDockerContainerDelete(d *schema.ResourceData, meta interface{}) err
 	d.SetId("")
 	return nil
 }
+
+// TODO move to separate flattener file
 
 func stringListToStringSlice(stringList []interface{}) []string {
 	ret := []string{}

--- a/docker/resource_docker_container_test.go
+++ b/docker/resource_docker_container_test.go
@@ -376,6 +376,51 @@ func TestAccDockerContainer_device(t *testing.T) {
 		},
 	})
 }
+func TestAccDockerContainer_port_internal(t *testing.T) {
+	t.Skip("Skipped: needs to be fixed")
+	var c types.ContainerJSON
+
+	testCheck := func(*terraform.State) error {
+		portMap := c.NetworkSettings.NetworkSettingsBase.Ports
+		portBindings, ok := portMap["80/tcp"]
+		if !ok || len(portMap["80/tcp"]) == 0 {
+			return fmt.Errorf("Port 80 on tcp is not set")
+		}
+
+		portBindingsLength := len(portBindings)
+		if portBindingsLength != 1 {
+			return fmt.Errorf("Expected 1 binding on port 80, but was %d", portBindingsLength)
+		}
+
+		if len(portBindings[0].HostIP) == 0 {
+			return fmt.Errorf("Expected host IP to be set, but was empty")
+		}
+
+		if len(portBindings[0].HostPort) == 0 {
+			return fmt.Errorf("Expected host port to be set, but was empty")
+		}
+
+		return nil
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDockerContainerInternalPortConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccContainerRunning("docker_container.foo", &c),
+					testCheck,
+					resource.TestCheckResourceAttr("docker_container.foo", "name", "tf-test"),
+					resource.TestCheckResourceAttr("docker_container.foo", "ports.#", "1"),
+					// Note: cannot be tested because the external port > 32768 is generated and so the
+					// hash of the port set changes every time: ports.425894982.external
+				),
+			},
+		},
+	})
+}
 func TestAccDockerContainer_port(t *testing.T) {
 	var c types.ContainerJSON
 
@@ -411,6 +456,12 @@ func TestAccDockerContainer_port(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccContainerRunning("docker_container.foo", &c),
 					testCheck,
+					resource.TestCheckResourceAttr("docker_container.foo", "name", "tf-test"),
+					resource.TestCheckResourceAttr("docker_container.foo", "ports.#", "1"),
+					resource.TestCheckResourceAttr("docker_container.foo", "ports.2498386340.internal", "80"),
+					resource.TestCheckResourceAttr("docker_container.foo", "ports.2498386340.ip", "0.0.0.0"),
+					resource.TestCheckResourceAttr("docker_container.foo", "ports.2498386340.protocol", "tcp"),
+					resource.TestCheckResourceAttr("docker_container.foo", "ports.2498386340.external", "32787"),
 				),
 			},
 		},
@@ -581,9 +632,25 @@ resource "docker_container" "foo" {
 }
 `
 
+const testAccDockerContainerInternalPortConfig = `
+resource "docker_image" "foo" {
+	name = "nginx:latest"
+	keep_locally = true
+}
+
+resource "docker_container" "foo" {
+	name = "tf-test"
+	image = "${docker_image.foo.latest}"
+	
+	ports {
+		internal = "80"
+	}
+}
+`
 const testAccDockerContainerPortConfig = `
 resource "docker_image" "foo" {
 	name = "nginx:latest"
+	keep_locally = true
 }
 
 resource "docker_container" "foo" {
@@ -591,7 +658,8 @@ resource "docker_container" "foo" {
 	image = "${docker_image.foo.latest}"
 
 	ports {
-    internal = "80"
+		internal = "80"
+		external = "32787"
 	}
 }
 `

--- a/docker/resource_docker_container_test.go
+++ b/docker/resource_docker_container_test.go
@@ -377,7 +377,6 @@ func TestAccDockerContainer_device(t *testing.T) {
 	})
 }
 func TestAccDockerContainer_port_internal(t *testing.T) {
-	t.Skip("Skipped: needs to be fixed")
 	var c types.ContainerJSON
 
 	testCheck := func(*terraform.State) error {
@@ -414,8 +413,10 @@ func TestAccDockerContainer_port_internal(t *testing.T) {
 					testCheck,
 					resource.TestCheckResourceAttr("docker_container.foo", "name", "tf-test"),
 					resource.TestCheckResourceAttr("docker_container.foo", "ports.#", "1"),
-					// Note: cannot be tested because the external port > 32768 is generated and so the
-					// hash of the port set changes every time: ports.425894982.external
+					resource.TestCheckResourceAttr("docker_container.foo", "ports.2978131916.internal", "80"),
+					resource.TestCheckResourceAttr("docker_container.foo", "ports.2978131916.ip", "0.0.0.0"),
+					resource.TestCheckResourceAttr("docker_container.foo", "ports.2978131916.protocol", "tcp"),
+					resource.TestCheckResourceAttr("docker_container.foo", "ports.2978131916.external", "32678"),
 				),
 			},
 		},

--- a/website/docs/r/container.html.markdown
+++ b/website/docs/r/container.html.markdown
@@ -121,11 +121,13 @@ resource "docker_container" "ubuntu" {
 the port mappings of the container. Each `ports` block supports
 the following:
 
-* `internal` - (Required, int) Port within the container.
-* `external` - (Required, int) Port exposed out of the container.
+* `internal` - (Optional, int) Port within the container.
+* `external` - (Optional, int) Port exposed out of the container.
 * `ip` - (Optional, string) IP address/mask that can access this port.
 * `protocol` - (Optional, string) Protocol that can be used over this port,
   defaults to TCP.
+
+One of `internal` or `external` must be set.
 
 <a id="extra_hosts"></a>
 ### Extra Hosts

--- a/website/docs/r/container.html.markdown
+++ b/website/docs/r/container.html.markdown
@@ -121,13 +121,11 @@ resource "docker_container" "ubuntu" {
 the port mappings of the container. Each `ports` block supports
 the following:
 
-* `internal` - (Optional, int) Port within the container.
-* `external` - (Optional, int) Port exposed out of the container.
-* `ip` - (Optional, string) IP address/mask that can access this port.
+* `internal` - (Required, int) Port within the container.
+* `external` - (Optional, int) Port exposed out of the container, defaults to `32768`.
+* `ip` - (Optional, string) IP address/mask that can access this port, default to `0.0.0.0`
 * `protocol` - (Optional, string) Protocol that can be used over this port,
   defaults to TCP.
-
-One of `internal` or `external` must be set.
 
 <a id="extra_hosts"></a>
 ### Extra Hosts


### PR DESCRIPTION
## Fixes the ports on containers. 
Specifically the following issues:
- [x] #8 
- [x] #89 
- [x] #73

## Known testing problems:
Cannot be tested because the external port > 32768 is generated and so the hash of the port set changes every time: `ports.425894982.external`
```
testValueHigherEqualThan("docker_container.foo", "ports.425894982.external", "32768"),
```