### PR TITLE
Add container static IPv4/IPv6 address

### DIFF
--- a/docker/resource_docker_container.go
+++ b/docker/resource_docker_container.go
@@ -447,14 +447,6 @@ func resourceDockerContainer() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"network_alias": &schema.Schema{
-				Type:     schema.TypeSet,
-				Optional: true,
-				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
-			},
-
 			"network_mode": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -465,8 +457,32 @@ func resourceDockerContainer() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"aliases": &schema.Schema{
+							Type:     schema.TypeSet,
+							Optional: true,
+							ForceNew: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
+						},
+						"ipv4_address": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"ipv6_address": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+					},
+				},
 			},
 
 			"pid_mode": &schema.Schema{

--- a/docker/resource_docker_container_test.go
+++ b/docker/resource_docker_container_test.go
@@ -821,6 +821,123 @@ func TestAccDockerContainer_nostart(t *testing.T) {
 	})
 }
 
+func TestAccDockerContainer_ipv4address(t *testing.T) {
+	var c types.ContainerJSON
+
+	testCheck := func(*terraform.State) error {
+		networks := c.NetworkSettings.Networks
+
+		if len(networks) != 1 {
+			return fmt.Errorf("Container doesn't have a correct network")
+		}
+		if _, ok := networks["tf-test"]; !ok {
+			return fmt.Errorf("Container doesn't have a correct network")
+		}
+		if c.NetworkSettings.Networks["tf-test"].IPAMConfig == nil {
+			return fmt.Errorf("Container doesn't have a correct IPAM config")
+		}
+		if c.NetworkSettings.Networks["tf-test"].IPAMConfig.IPv4Address != "10.0.1.123" {
+			return fmt.Errorf("Container doesn't have a correct IPv4 address")
+		}
+
+		return nil
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDockerContainerNetworksIPv4AddressConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccContainerRunning("docker_container.foo", &c),
+					testCheck,
+					resource.TestCheckResourceAttr("docker_container.foo", "name", "tf-test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDockerContainer_ipv6address(t *testing.T) {
+	var c types.ContainerJSON
+
+	testCheck := func(*terraform.State) error {
+		networks := c.NetworkSettings.Networks
+
+		if len(networks) != 1 {
+			return fmt.Errorf("Container doesn't have a correct network")
+		}
+		if _, ok := networks["tf-test"]; !ok {
+			return fmt.Errorf("Container doesn't have a correct network")
+		}
+		if c.NetworkSettings.Networks["tf-test"].IPAMConfig == nil {
+			return fmt.Errorf("Container doesn't have a correct IPAM config")
+		}
+		if c.NetworkSettings.Networks["tf-test"].IPAMConfig.IPv6Address != "fd00:0:0:0::123" {
+			return fmt.Errorf("Container doesn't have a correct IPv6 address")
+		}
+
+		return nil
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDockerContainerNetworksIPv6AddressConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccContainerRunning("docker_container.foo", &c),
+					testCheck,
+					resource.TestCheckResourceAttr("docker_container.foo", "name", "tf-test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDockerContainer_dualstackaddress(t *testing.T) {
+	var c types.ContainerJSON
+
+	testCheck := func(*terraform.State) error {
+		networks := c.NetworkSettings.Networks
+
+		if len(networks) != 1 {
+			return fmt.Errorf("Container doesn't have a correct network")
+		}
+		if _, ok := networks["tf-test"]; !ok {
+			return fmt.Errorf("Container doesn't have a correct network")
+		}
+		if c.NetworkSettings.Networks["tf-test"].IPAMConfig == nil {
+			return fmt.Errorf("Container doesn't have a correct IPAM config")
+		}
+		if c.NetworkSettings.Networks["tf-test"].IPAMConfig.IPv4Address != "10.0.1.123" {
+			return fmt.Errorf("Container doesn't have a correct IPv4 address")
+		}
+		if c.NetworkSettings.Networks["tf-test"].IPAMConfig.IPv6Address != "fd00:0:0:0::123" {
+			return fmt.Errorf("Container doesn't have a correct IPv6 address")
+		}
+
+		return nil
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDockerContainerNetworksDualStackAddressConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccContainerRunning("docker_container.foo", &c),
+					testCheck,
+					resource.TestCheckResourceAttr("docker_container.foo", "name", "tf-test"),
+				),
+			},
+		},
+	})
+}
+
 func testAccContainerRunning(n string, container *types.ContainerJSON) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -1318,5 +1435,80 @@ resource "docker_container" "foo" {
   image    = "nginx:latest"
   start    = false
   must_run = false
+}
+`
+const testAccDockerContainerNetworksIPv4AddressConfig = `
+resource "docker_network" "test" {
+	name = "tf-test"
+	ipam_config {
+		subnet = "10.0.1.0/24"
+	}
+}
+resource "docker_image" "foo" {
+	name = "nginx:latest"
+	keep_locally = true
+}
+resource "docker_container" "foo" {
+	name = "tf-test"
+	image = "${docker_image.foo.latest}"
+	networks = [
+		{
+			name = "${docker_network.test.name}",
+			ipv4_address = "10.0.1.123"
+		}
+	]
+}
+`
+
+const testAccDockerContainerNetworksIPv6AddressConfig = `
+resource "docker_network" "test" {
+	name = "tf-test"
+	ipv6 = true
+	ipam_config {
+		subnet = "fd00::1/64"
+	}
+}
+resource "docker_image" "foo" {
+	name = "nginx:latest"
+	keep_locally = true
+}
+resource "docker_container" "foo" {
+	name = "tf-test"
+	image = "${docker_image.foo.latest}"
+	networks = [
+		{
+			name = "${docker_network.test.name}",
+			ipv6_address = "fd00:0:0:0::123"
+		}
+	]
+}
+`
+const testAccDockerContainerNetworksDualStackAddressConfig = `
+resource "docker_network" "test" {
+	name = "tf-test"
+	ipv6 = true
+	ipam_config = [
+		{
+			subnet = "10.0.1.0/24"
+		},
+		{
+			subnet = "fd00::1/64"
+		}
+	]
+}
+resource "docker_image" "foo" {
+	name = "nginx:latest"
+	keep_locally = true
+}
+resource "docker_container" "foo" {
+	name = "tf-test"
+	image = "${docker_image.foo.latest}"
+	networks = [
+		{
+			name = "${docker_network.test.name}",
+			ipv4_address = "10.0.1.123"
+			ipv6_address = "fd00:0:0:0::123"
+		}
+	]
 }
 `

--- a/docker/resource_docker_network_test.go
+++ b/docker/resource_docker_network_test.go
@@ -75,7 +75,7 @@ func TestAccDockerNetwork_internal(t *testing.T) {
 			resource.TestStep{
 				Config: testAccDockerNetworkInternalConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccNetwork("docker_network.foobar", &n),
+					testAccNetwork("docker_network.foo", &n),
 					testAccNetworkInternal(&n, true),
 				),
 			},
@@ -93,8 +93,8 @@ func testAccNetworkInternal(network *types.NetworkResource, internal bool) resou
 }
 
 const testAccDockerNetworkInternalConfig = `
-resource "docker_network" "foobar" {
-  name = "foobar"
+resource "docker_network" "foo" {
+  name = "bar"
   internal = true
 }
 `
@@ -109,7 +109,7 @@ func TestAccDockerNetwork_attachable(t *testing.T) {
 			resource.TestStep{
 				Config: testAccDockerNetworkAttachableConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccNetwork("docker_network.foobar", &n),
+					testAccNetwork("docker_network.foo", &n),
 					testAccNetworkAttachable(&n, true),
 				),
 			},
@@ -127,9 +127,125 @@ func testAccNetworkAttachable(network *types.NetworkResource, attachable bool) r
 }
 
 const testAccDockerNetworkAttachableConfig = `
-resource "docker_network" "foobar" {
-  name = "foobar"
+resource "docker_network" "foo" {
+  name = "bar"
   attachable = true
+}
+`
+
+//func TestAccDockerNetwork_ingress(t *testing.T) {
+//	var n types.NetworkResource
+//
+//	resource.Test(t, resource.TestCase{
+//		PreCheck:  func() { testAccPreCheck(t) },
+//		Providers: testAccProviders,
+//		Steps: []resource.TestStep{
+//			resource.TestStep{
+//				Config: testAccDockerNetworkIngressConfig,
+//				Check: resource.ComposeTestCheckFunc(
+//					testAccNetwork("docker_network.foo", &n),
+//					testAccNetworkIngress(&n, true),
+//				),
+//			},
+//		},
+//	})
+//}
+//
+//func testAccNetworkIngress(network *types.NetworkResource, internal bool) resource.TestCheckFunc {
+//	return func(s *terraform.State) error {
+//		if network.Internal != internal {
+//			return fmt.Errorf("Bad value for attribute 'ingress': %t", network.Ingress)
+//		}
+//		return nil
+//	}
+//}
+//
+//const testAccDockerNetworkIngressConfig = `
+//resource "docker_network" "foo" {
+//  name = "bar"
+//  ingress = true
+//}
+//`
+
+func TestAccDockerNetwork_ipv4(t *testing.T) {
+	var n types.NetworkResource
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDockerNetworkIPv4Config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccNetwork("docker_network.foo", &n),
+					testAccNetworkIPv4(&n, true),
+				),
+			},
+		},
+	})
+}
+
+func testAccNetworkIPv4(network *types.NetworkResource, internal bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if len(network.IPAM.Config) != 1 {
+			return fmt.Errorf("Bad value for IPAM configuration count: %d", len(network.IPAM.Config))
+		}
+		if network.IPAM.Config[0].Subnet != "10.0.1.0/24" {
+			return fmt.Errorf("Bad value for attribute 'subnet': %v", network.IPAM.Config[0].Subnet)
+		}
+		return nil
+	}
+}
+
+const testAccDockerNetworkIPv4Config = `
+resource "docker_network" "foo" {
+  name = "bar"
+  ipam_config {
+    subnet = "10.0.1.0/24"
+  }
+}
+`
+
+func TestAccDockerNetwork_ipv6(t *testing.T) {
+	var n types.NetworkResource
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDockerNetworkIPv6Config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccNetwork("docker_network.foo", &n),
+					testAccNetworkIPv6(&n, true),
+				),
+			},
+		},
+	})
+}
+
+func testAccNetworkIPv6(network *types.NetworkResource, internal bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if !network.EnableIPv6 {
+			return fmt.Errorf("Bad value for attribute 'ipv6': %t", network.EnableIPv6)
+		}
+		if len(network.IPAM.Config) != 2 {
+			return fmt.Errorf("Bad value for IPAM configuration count: %d", len(network.IPAM.Config))
+		}
+		if network.IPAM.Config[1].Subnet != "fd00::1/64" {
+			return fmt.Errorf("Bad value for attribute 'subnet': %v", network.IPAM.Config[0].Subnet)
+		}
+		return nil
+	}
+}
+
+const testAccDockerNetworkIPv6Config = `
+resource "docker_network" "foo" {
+  name = "bar"
+  ipv6 = true
+  ipam_config {
+    subnet = "fd00::1/64"
+  }
 }
 `
 
@@ -143,8 +259,8 @@ func TestAccDockerNetwork_labels(t *testing.T) {
 			resource.TestStep{
 				Config: testAccDockerNetworkLabelsConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccNetwork("docker_network.foobar", &n),
-					testAccNetworkLabel(&n, "com.docker.compose.network", "foobar"),
+					testAccNetwork("docker_network.foo", &n),
+					testAccNetworkLabel(&n, "com.docker.compose.network", "foo"),
 					testAccNetworkLabel(&n, "com.docker.compose.project", "test"),
 				),
 			},
@@ -162,10 +278,10 @@ func testAccNetworkLabel(network *types.NetworkResource, name string, value stri
 }
 
 const testAccDockerNetworkLabelsConfig = `
-resource "docker_network" "foobar" {
-  name = "test_foobar"
+resource "docker_network" "foo" {
+  name = "test_foo"
   labels {
-    "com.docker.compose.network" = "foobar"
+    "com.docker.compose.network" = "foo"
     "com.docker.compose.project" = "test"
   }
 }


### PR DESCRIPTION
This PR allows to set a static IPv4 / IPv6 address to a `docker_container` resource. 

This new code requires to refactor the `networks` options, moving to a `TypeSet` attribute to have new and specific options per network. 

Sample terraform plan with a dual-stack IPv4/IPv6 network:

```
resource "docker_network" "default" {
  name = "test_default"

  ipv6       = true # ipv6 must be enabled on the docker daemon
  attachable = true

  ipam_config = [
    {
      subnet = "10.0.1.0/24"        # custom IPv4 subnet (otherwise a new one is allocated even if IPv6 is enabled)
    },
    {
      subnet = "fd00:0:0:1::/64"    # custom IPv6 subnet
    },
  ]

  labels {
    "com.docker.compose.network" = "dual-stack"
    "com.docker.compose.project" = "test"
  }
}

resource "docker_container" "test" {
  count = 1

  image   = "bhuisgen/alpine-portainer:prod"
  name    = "test_portainer_${count.index + 1}"
  restart = "unless-stopped"

  labels {
    "com.docker.compose.container-number" = "${count.index + 1}"
    "com.docker.compose.project"          = "test"
    "com.docker.compose.service"          = "portainer"
    "com.docker.compose.oneoff"           = "False"
    "com.docker.compose.version"          = "1.22.0"
  }

  # new networks syntax with specific options per network
  networks = [
    {
      name         = "${docker_network.dual-stack.id}" # the name of the network
      ipv4_address = "10.0.1.123"                      # the static IPv4 if network (dynamic IP if missing)
      ipv6_address = "fd00:0:0:1::123"                 # the static IPv6 if network is IPv6 enabled
      aliases      = ["portainer-dualstack"]           # the CT aliases on this network
    },
  ]

  ports {
    external = "10000" # only IPv4 NAT is configured, you should use the CT IPv6 address as public address or configure manually NATv6
    internal = "9000"
  }

  volumes {
    host_path      = "/etc/localtime"
    container_path = "/etc/localtime"
    read_only      = true
  }

  volumes {
    host_path      = "/var/run/docker.sock"
    container_path = "/var/run/docker.sock"
  }

  env = [
    "ENV=local",
    "PORTAINER_TEMPLATE=generic",
  ]

  log_driver = "syslog"

  log_opts {
    "tag" = "{{.Name}}/{{.ID}}"
  }

  must_run = true
}
```

The docker engine must be configured to accept IPv6 and with a free subnet CIDR else the acceptance tests won't pass. In my test setup, I use these settings:

```
{
    "bip": "172.30.0.1/24",
    "ipv6": true,
    "fixed-cidr-v6": "fc00::/8"
}
```

Tests output:
```
=== RUN   TestAccDockerContainer_ipv4address
--- PASS: TestAccDockerContainer_ipv4address (24.14s)
=== RUN   TestAccDockerContainer_ipv6address
--- PASS: TestAccDockerContainer_ipv6address (22.51s)
=== RUN   TestAccDockerContainer_dualstackaddress
--- PASS: TestAccDockerContainer_dualstackaddress (22.53s)
=== RUN   TestAccDockerNetwork_ipv4
--- PASS: TestAccDockerNetwork_ipv4 (21.38s)
=== RUN   TestAccDockerNetwork_ipv6
--- PASS: TestAccDockerNetwork_ipv6 (21.31s)
```