### PR TITLE
Update service.html fixed typo `tmpf_options`

### DIFF
--- a/website/docs/r/service.html.markdown
+++ b/website/docs/r/service.html.markdown
@@ -362,7 +362,7 @@ the following:
   * `driver_config` - (Optional, map) The name of the driver to create the volume.
     * `name` - (Optional, string) The name of the driver to create the volume.
     * `options` - (Optional, map of key/value pairs) Options for the driver.
-* `tmpf_options` - (Optional, map) Optional configuration for the `tmpf` type.
+* `tmpfs_options` - (Optional, map) Optional configuration for the `tmpf` type.
   * `size_bytes` - (Optional, int) The size for the tmpfs mount in bytes. 
   * `mode` - (Optional, int) The permission mode for the tmpfs mount in an integer.
 


### PR DESCRIPTION
Fixed a typo in `service.html.markdown` file, updated `tmpf_options` to `tmpfs_options`.