### PR TITLE
Normalize blank port IP's to 0.0.0.0

### DIFF
--- a/docker/resource_docker_container.go
+++ b/docker/resource_docker_container.go
@@ -249,6 +249,14 @@ func resourceDockerContainer() *schema.Resource {
 							Default:  "0.0.0.0",
 							Optional: true,
 							ForceNew: true,
+							StateFunc: func(val interface{}) string {
+								// Empty IP assignments default to 0.0.0.0
+								if val.(string) == "" {
+									return "0.0.0.0"
+								}
+
+								return val.(string)
+							},
 						},
 
 						"protocol": &schema.Schema{


### PR DESCRIPTION
Docker treats blank strings for an exposed port's IP as 0.0.0.0, but terraform doesn't recognise this. This leads to a mismatch when terraform checks the state against docker. This PR just normalizes empty values to be 0.0.0.0 when stored in the state so they match up.

I've manually tested this and it fixes #127. I wasn't sure how best to automate a test but if someone can point me in the right direction I'm happy to give it a go.