### PR TITLE
Shared volume mount support for docker container resource

### DIFF
--- a/docker/resource_docker_container.go
+++ b/docker/resource_docker_container.go
@@ -323,6 +323,12 @@ func resourceDockerContainer() *schema.Resource {
 							Optional: true,
 							ForceNew: true,
 						},
+
+						"shared": &schema.Schema{
+							Type:     schema.TypeBool,
+							Optional: true,
+							ForceNew: true,
+						},
 					},
 				},
 			},

--- a/docker/resource_docker_container_funcs.go
+++ b/docker/resource_docker_container_funcs.go
@@ -789,6 +789,7 @@ func volumeSetToDockerVolumes(volumes *schema.Set) (map[string]struct{}, []strin
 			volumeName = volume["host_path"].(string)
 		}
 		readOnly := volume["read_only"].(bool)
+		shared := volume["shared"].(bool)
 
 		switch {
 		case len(fromContainer) == 0 && len(containerPath) == 0:
@@ -803,7 +804,11 @@ func volumeSetToDockerVolumes(volumes *schema.Set) (map[string]struct{}, []strin
 				readWrite = "ro"
 			}
 			retVolumeMap[containerPath] = struct{}{}
-			retHostConfigBinds = append(retHostConfigBinds, volumeName+":"+containerPath+":"+readWrite)
+			opts := volumeName + ":" + containerPath + ":" + readWrite
+			if shared == true {
+				opts += "," + "shared"
+			}
+			retHostConfigBinds = append(retHostConfigBinds, opts)
 		default:
 			retVolumeMap[containerPath] = struct{}{}
 		}

--- a/docker/resource_docker_container_test.go
+++ b/docker/resource_docker_container_test.go
@@ -1279,6 +1279,7 @@ resource "docker_container" "foo" {
         volume_name = "${docker_volume.foo.name}"
         container_path = "/tmp/volume"
         read_only = false
+        shared = true
     }
 }
 `

--- a/website/docs/r/container.html.markdown
+++ b/website/docs/r/container.html.markdown
@@ -194,6 +194,9 @@ the following:
   volume will be mounted.
 * `read_only` - (Optional, bool) If true, this volume will be readonly.
   Defaults to false.
+* `shared` - (Optional, bool) If true, this volume will be shared.
+	Defaults to false. See [Docker documentation ][shareddocs]for more
+	details.
 
 One of `from_container`, `host_path` or `volume_name` must be set.
 
@@ -280,3 +283,4 @@ The following attributes are exported:
 
 
 [linkdoc] https://docs.docker.com/network/links/
+[shareddocs] https://docs.docker.com/engine/reference/run/#volume-shared-filesystems


### PR DESCRIPTION
I tried to find a clean way to implement this, but docker has too many volume mount options that don't fit with the way `read_only` is implemented already.

Stumbled upon this while trying to run kubelet as a docker container over a remote docker API.