### PR TITLE
Added support to build docker images

### DIFF
--- a/docker/resource_docker_image.go
+++ b/docker/resource_docker_image.go
@@ -42,6 +42,30 @@ func resourceDockerImage() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
+			"build": &schema.Schema{
+				Type:          schema.TypeSet,
+				Optional:      true,
+				MaxItems:      1,
+				ConflictsWith: []string{"pull_triggers", "pull_trigger"},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"context": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"dockerfile": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "Dockerfile",
+						},
+						"buildargs": &schema.Schema{
+							Type:     schema.TypeMap,
+							Optional: true,
+							Elem:     schema.TypeString,
+						},
+					},
+				},
+			},
 		},
 	}
 }

--- a/docker/resource_docker_image_funcs.go
+++ b/docker/resource_docker_image_funcs.go
@@ -1,9 +1,14 @@
 package docker
 
 import (
+	"archive/tar"
 	"context"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"log"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"bytes"
@@ -12,18 +17,27 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/jsonmessage"
+	"github.com/docker/docker/pkg/term"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
 func resourceDockerImageCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ProviderConfig).DockerClient
-	apiImage, err := findImage(d, client, meta.(*ProviderConfig).AuthConfigs)
-	if err != nil {
-		return fmt.Errorf("Unable to read Docker image into resource: %s", err)
-	}
 
-	d.SetId(apiImage.ID + d.Get("name").(string))
-	d.Set("latest", apiImage.ID)
+	buildConfigList := d.Get("build").(*schema.Set).List()
+
+	if len(buildConfigList) == 1 {
+		buildDockerImage(client, d.Get("name").(string), buildConfigList[0].(map[string]interface{}))
+	} else {
+		apiImage, err := findImage(d, client, meta.(*ProviderConfig).AuthConfigs)
+		if err != nil {
+			return fmt.Errorf("Unable to read Docker image into resource: %s", err)
+		}
+
+		d.SetId(apiImage.ID + d.Get("name").(string))
+		d.Set("latest", apiImage.ID)
+	}
 
 	return resourceDockerImageRead(d, meta)
 }
@@ -231,4 +245,103 @@ func findImage(d *schema.ResourceData, client *client.Client, authConfig *AuthCo
 	}
 
 	return nil, fmt.Errorf("Unable to find or pull image %s", imageName)
+}
+
+func buildContextTar(buildContext string) (string, error) {
+	// Create our Temp File:  This will create a filename like /tmp/terraform-provider-docker-123456.tar
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "terraform-provider-docker-*.tar")
+	if err != nil {
+		return "", fmt.Errorf("Cannot create temporary file - %v", err.Error())
+	}
+
+	defer tmpFile.Close()
+
+	if _, err = os.Stat(buildContext); err != nil {
+		return "", fmt.Errorf("Unable to read build context - %v", err.Error())
+	}
+
+	tw := tar.NewWriter(tmpFile)
+	defer tw.Close()
+
+	err = filepath.Walk(buildContext, func(file string, info os.FileInfo, err error) error {
+
+		// return on any error
+		if err != nil {
+			return err
+		}
+
+		// create a new dir/file header
+		header, err := tar.FileInfoHeader(info, info.Name())
+		if err != nil {
+			return err
+		}
+
+		// update the name to correctly reflect the desired destination when untaring
+		header.Name = strings.TrimPrefix(strings.Replace(file, buildContext, "", -1), string(filepath.Separator))
+
+		// write the header
+		if err := tw.WriteHeader(header); err != nil {
+			return err
+		}
+
+		// return on non-regular files (thanks to [kumo](https://medium.com/@komuw/just-like-you-did-fbdd7df829d3) for this suggested update)
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+
+		// open files for taring
+		f, err := os.Open(file)
+		if err != nil {
+			return err
+		}
+
+		// copy file data into tar writer
+		if _, err := io.Copy(tw, f); err != nil {
+			return err
+		}
+
+		// manually close here after each file operation; defering would cause each file close
+		// to wait until all operations have completed.
+		f.Close()
+
+		return nil
+
+	})
+
+	return tmpFile.Name(), nil
+}
+
+func buildDockerImage(client *client.Client, tag string, buildOptions map[string]interface{}) error {
+	dockerContextTarPath, err := buildContextTar(buildOptions["context"].(string))
+	defer os.Remove(dockerContextTarPath)
+
+	dockerBuildContext, err := os.Open(dockerContextTarPath)
+	defer dockerBuildContext.Close()
+
+	options := types.ImageBuildOptions{
+		SuppressOutput: false,
+		Remove:         true,
+		ForceRemove:    true,
+		PullParent:     true,
+		Tags:           []string{tag},
+		Dockerfile:     buildOptions["dockerfile"].(string),
+		BuildArgs:      mapTypeMapValsToStringPtr(buildOptions["buildargs"].(map[string]interface{})),
+	}
+
+	buildResponse, err := client.ImageBuild(context.Background(), dockerBuildContext, options)
+	if err != nil {
+		return err
+	}
+	defer buildResponse.Body.Close()
+
+	termFd, isTerm := term.GetFdInfo(os.Stderr)
+	return jsonmessage.DisplayJSONMessagesStream(buildResponse.Body, os.Stderr, termFd, isTerm, nil)
+}
+
+func mapTypeMapValsToStringPtr(typeMap map[string]interface{}) map[string]*string {
+	mapped := make(map[string]*string, len(typeMap))
+	for k, v := range typeMap {
+		*mapped[k] = v.(string)
+	}
+	return mapped
 }


### PR DESCRIPTION
First stab at #33.
I could use some help in getting this fleshed out.

- [x] Build docker images
- [ ] Verify and add support for `.dockerignore` if required.
- [ ] Compute hash for docker context to invalidate state.
- [ ] Expose docker image hash as attribute.
- [ ] Create `resource_docker_registry_image` to upload the created image. Use docker image hash to re-upload when necessary.