### PR TITLE
tests: Skip test if swap limit isn't available

### DIFF
--- a/docker/provider_test.go
+++ b/docker/provider_test.go
@@ -55,4 +55,9 @@ func testAccPreCheck(t *testing.T) {
 	if v := os.Getenv("DOCKER_PRIVATE_IMAGE"); v == "" {
 		t.Fatalf("DOCKER_PRIVATE_IMAGE must be set for acceptance tests")
 	}
+
+	err := testAccProvider.Configure(terraform.NewResourceConfig(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
 }

--- a/docker/resource_docker_container_test.go
+++ b/docker/resource_docker_container_test.go
@@ -335,7 +335,7 @@ func TestAccDockerContainer_customized(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccCheckSwapLimit(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
@@ -347,6 +347,18 @@ func TestAccDockerContainer_customized(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccCheckSwapLimit(t *testing.T) {
+	client := testAccProvider.Meta().(*ProviderConfig).DockerClient
+	info, err := client.Info(context.Background())
+	if err != nil {
+		t.Fatalf("Failed to check swap limit capability: %s", err)
+	}
+
+	if !info.SwapLimit {
+		t.Skip("Swap limit capability not available, skipping test")
+	}
 }
 
 func TestAccDockerContainer_upload(t *testing.T) {
@@ -1187,7 +1199,7 @@ resource "docker_container" "foo" {
 	cpu_set = "0-1"
 
 	capabilities {
-		add= ["ALL"]
+		add  = ["ALL"]
 		drop = ["SYS_ADMIN"]
 	}
 


### PR DESCRIPTION
This allows us to skip test which would otherwise fail on platform that don't support swap limit capability.