### PR TITLE
WIP: Skip blank secrets

### DIFF
--- a/docker/resource_docker_service_funcs.go
+++ b/docker/resource_docker_service_funcs.go
@@ -906,7 +906,6 @@ func createContainerSpec(v interface{}) (*swarm.ContainerSpec, error) {
 
 				for _, rawSecret := range value.(*schema.Set).List() {
 					rawSecret := rawSecret.(map[string]interface{})
-
 					secretID := rawSecret["secret_id"].(string)
 					if len(secretID) == 0 {
 						log.Printf("[WARN] secret_id field was empty. Excluding secret from output")

--- a/docker/resource_docker_service_funcs.go
+++ b/docker/resource_docker_service_funcs.go
@@ -906,8 +906,15 @@ func createContainerSpec(v interface{}) (*swarm.ContainerSpec, error) {
 
 				for _, rawSecret := range value.(*schema.Set).List() {
 					rawSecret := rawSecret.(map[string]interface{})
+
+					secretID := rawSecret["secret_id"].(string)
+					if len(secretID) == 0 {
+						log.Printf("[WARN] secret_id field was empty. Excluding secret from output")
+						continue
+					}
+
 					secret := swarm.SecretReference{
-						SecretID: rawSecret["secret_id"].(string),
+						SecretID: secretID,
 						File: &swarm.SecretReferenceFileTarget{
 							Name: rawSecret["file_name"].(string),
 							UID:  "0",

--- a/docker/resource_docker_service_test.go
+++ b/docker/resource_docker_service_test.go
@@ -394,20 +394,20 @@ func TestAccDockerService_emptySecrets(t *testing.T) {
 					task_spec {
 						container_spec {
 							image = "127.0.0.1:15000/tftest-service:v1"
-						}
 
-						secrets = [
-							{
-								secret_id   = "${docker_secret.service_secret.id}"
-								secret_name = "${docker_secret.service_secret.name}"
-								file_name = "/secrets.json"
-							},
-							{
-								secret_id   = ""
-								secret_name = ""
-								file_name = ""
-							},
-						]
+							secrets = [
+								{
+									secret_id   = "${docker_secret.service_secret.id}"
+									secret_name = "${docker_secret.service_secret.name}"
+									file_name = "/secrets.json"
+								},
+								{
+									secret_id   = ""
+									secret_name = ""
+									file_name = ""
+								},
+							]
+						}
 					}
 				}
 				`,

--- a/docker/resource_docker_service_test.go
+++ b/docker/resource_docker_service_test.go
@@ -384,6 +384,11 @@ func TestAccDockerService_emptySecrets(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: `
+				resource "docker_secret" "service_secret" {
+					name = "tftest-mysecret"
+					data = "ewogICJrZXkiOiAiUVdFUlRZIgp9"
+				}
+
 				resource "docker_service" "foo" {
 					name     = "tftest-service-basic"
 					task_spec {

--- a/docker/resource_docker_service_test.go
+++ b/docker/resource_docker_service_test.go
@@ -377,6 +377,46 @@ func TestAccDockerService_full(t *testing.T) {
 	})
 }
 
+func TestAccDockerService_emptySecrets(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+				resource "docker_service" "foo" {
+					name     = "tftest-service-basic"
+					task_spec {
+						container_spec {
+							image = "127.0.0.1:15000/tftest-service:v1"
+						}
+
+						secrets = [
+							{
+								secret_id   = "${docker_secret.service_secret.id}"
+								secret_name = "${docker_secret.service_secret.name}"
+								file_name = "/secrets.json"
+							},
+							{
+								secret_id   = ""
+								secret_name = ""
+								file_name = ""
+							},
+						]
+					}
+				}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("docker_service.foo", "id", serviceIDRegex),
+					resource.TestCheckResourceAttr("docker_service.foo", "name", "tftest-service-basic"),
+					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.image", "127.0.0.1:15000/tftest-service:v1"),
+					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.secrets.#", "1"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDockerService_partialReplicated(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },


### PR DESCRIPTION
Allowing secrets in `docker_service` to be empty. If left empty a WARN will be issued and the secret will be excluded from the plan.

The reasoning behind this is around Terraform's (0.11) "list of maps" support. It is difficult to use and often seems to "flatten" the map, breaking the implementation.

An example of this behavior occurs in https://github.com/terraform-providers/terraform-provider-docker/issues/129.

---

Disclaimer: This is my first PR in this repository. Does it align with the owners' goals? Is it a idiomatic solution?