### PR TITLE
Fixes for flaky tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,8 @@ script:
 - make vet
 - make test
 - make testacc
-- make compile
-- make website-test
+#- make compile
+#- make website-test
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,8 @@ script:
 - make vet
 - make test
 - make testacc
-#- make compile
-#- make website-test
+- make compile
+- make website-test
 
 branches:
   only:

--- a/docker/resource_docker_service_funcs.go
+++ b/docker/resource_docker_service_funcs.go
@@ -58,21 +58,7 @@ func resourceDockerServiceCreate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	serviceOptions := types.ServiceCreateOptions{}
-	auth := types.AuthConfig{}
-	if v, ok := d.GetOk("auth"); ok {
-		auth = authToServiceAuth(v.(map[string]interface{}))
-	} else {
-		authConfigs := meta.(*ProviderConfig).AuthConfigs.Configs
-		if len(authConfigs) == 0 {
-			log.Printf("[DEBUG] AuthConfigs empty on create. Wait 3s and try again")
-			<-time.After(3 * time.Second)
-			authConfigs = meta.(*ProviderConfig).AuthConfigs.Configs
-		}
-		log.Printf("[DEBUG] Getting configs from '%v'", authConfigs)
-		auth = fromRegistryAuth(d.Get("task_spec.0.container_spec.0.image").(string), authConfigs)
-	}
-
-	marshalledAuth, _ := json.Marshal(auth) // https://docs.docker.com/engine/api/v1.37/#section/Versioning
+	marshalledAuth := retrieveAndMarshalAuth(d, meta, "create")
 	serviceOptions.EncodedRegistryAuth = base64.URLEncoding.EncodeToString(marshalledAuth)
 	serviceOptions.QueryRegistry = true
 	log.Printf("[DEBUG] Passing registry auth '%s'", serviceOptions.EncodedRegistryAuth)
@@ -167,25 +153,11 @@ func resourceDockerServiceUpdate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	updateOptions := types.ServiceUpdateOptions{}
-	auth := types.AuthConfig{}
-	if v, ok := d.GetOk("auth"); ok {
-		auth = authToServiceAuth(v.(map[string]interface{}))
-	} else {
-		authConfigs := meta.(*ProviderConfig).AuthConfigs.Configs
-		if len(authConfigs) == 0 {
-			log.Printf("[DEBUG] AuthConfigs empty on update. Wait 3s and try again")
-			<-time.After(3 * time.Second)
-			authConfigs = meta.(*ProviderConfig).AuthConfigs.Configs
-		}
-		log.Printf("[DEBUG] Getting configs from '%v'", authConfigs)
-		auth = fromRegistryAuth(d.Get("task_spec.0.container_spec.0.image").(string), authConfigs)
-	}
-
-	encodedJSON, err := json.Marshal(auth)
+	marshalledAuth := retrieveAndMarshalAuth(d, meta, "update")
 	if err != nil {
 		return fmt.Errorf("error creating auth config: %s", err)
 	}
-	updateOptions.EncodedRegistryAuth = base64.URLEncoding.EncodeToString(encodedJSON)
+	updateOptions.EncodedRegistryAuth = base64.URLEncoding.EncodeToString(marshalledAuth)
 
 	updateResponse, err := client.ServiceUpdate(context.Background(), d.Id(), service.Version, serviceSpec, updateOptions)
 	if err != nil {
@@ -1313,6 +1285,29 @@ func fromRegistryAuth(image string, authConfigs map[string]types.AuthConfig) typ
 	}
 
 	return types.AuthConfig{}
+}
+
+// retrieveAndMarshalAuth retrieves and marshals the service registry auth
+func retrieveAndMarshalAuth(d *schema.ResourceData, meta interface{}, stageType string) []byte {
+	auth := types.AuthConfig{}
+	if v, ok := d.GetOk("auth"); ok {
+		auth = authToServiceAuth(v.(map[string]interface{}))
+	} else {
+		authConfigs := meta.(*ProviderConfig).AuthConfigs.Configs
+		if len(authConfigs) == 0 {
+			log.Printf("[DEBUG] AuthConfigs empty on %s. Wait 3s and try again", stageType)
+			// sometimes the dockerconfig is read succesfully from disk but the
+			// call to create/update the service is faster. So we delay to prevent the
+			// passing of an empty auth configuration in this case
+			<-time.After(3 * time.Second)
+			authConfigs = meta.(*ProviderConfig).AuthConfigs.Configs
+		}
+		log.Printf("[DEBUG] Getting configs from '%v'", authConfigs)
+		auth = fromRegistryAuth(d.Get("task_spec.0.container_spec.0.image").(string), authConfigs)
+	}
+
+	marshalledAuth, _ := json.Marshal(auth) // https://docs.docker.com/engine/api/v1.37/#section/Versioning
+	return marshalledAuth
 }
 
 // stringSetToPlacementPrefs maps a string set to PlacementPreference

--- a/docker/resource_docker_service_test.go
+++ b/docker/resource_docker_service_test.go
@@ -736,6 +736,20 @@ func TestAccDockerService_updateMultiplePropertiesConverge(t *testing.T) {
 	configData := "ewogICJwcmVmaXgiOiAiMTIzIgp9"
 	secretData := "ewogICJrZXkiOiAiUVdFUlRZIgp9"
 	image := "127.0.0.1:15000/tftest-service:v1"
+	mounts := `
+		{
+			source = "${docker_volume.foo.name}"
+			target = "/mount/test"
+			type   = "volume"
+			read_only = true
+			volume_options {
+				labels {
+					env = "dev"
+					terraform = "true"
+				}
+			}
+		}
+	`
 	hosts := `
 		{
 			host = "testhost"
@@ -765,6 +779,32 @@ func TestAccDockerService_updateMultiplePropertiesConverge(t *testing.T) {
 	secretData2 := "ewogICJrZXkiOiAiUVdFUlRZIgp9" // UPDATED to YXCVB
 	image2 := "127.0.0.1:15000/tftest-service:v2"
 	healthcheckInterval2 := "2s"
+	mounts2 := `
+		{
+			source = "${docker_volume.foo.name}"
+			target = "/mount/test"
+			type   = "volume"
+			read_only = true
+			volume_options {
+				labels {
+					env = "dev"
+					terraform = "true"
+				}
+			}
+		},
+		{
+			source = "${docker_volume.foo2.name}"
+			target = "/mount/test2"
+			type   = "volume"
+			read_only = true
+			volume_options {
+				labels {
+					env = "dev"
+					terraform = "true"
+				}
+			}
+		}
+	`
 	hosts2 := `
 		{
 			host = "testhost2"
@@ -796,6 +836,7 @@ func TestAccDockerService_updateMultiplePropertiesConverge(t *testing.T) {
 	configData3 := configData2
 	secretData3 := secretData2
 	image3 := image2
+	mounts3 := mounts2
 	hosts3 := hosts2
 	logging3 := logging2
 	healthcheckInterval3 := healthcheckInterval2
@@ -807,7 +848,7 @@ func TestAccDockerService_updateMultiplePropertiesConverge(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(updateMultiplePropertiesConfigConverge, configData, secretData, image, hosts, healthcheckInterval, healthcheckTimeout, logging, replicas, portsSpec),
+				Config: fmt.Sprintf(updateMultiplePropertiesConfigConverge, configData, secretData, image, mounts, hosts, healthcheckInterval, healthcheckTimeout, logging, replicas, portsSpec),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr("docker_service.foo", "id", serviceIDRegex),
 					resource.TestCheckResourceAttr("docker_service.foo", "name", "tftest-fnf-service-up-crihiadr"),
@@ -841,6 +882,7 @@ func TestAccDockerService_updateMultiplePropertiesConverge(t *testing.T) {
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.hosts.1878413705.ip", "10.0.1.0"),
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.isolation", "default"),
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.labels.%", "0"),
+					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.mounts.#", "1"),
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.privileges.#", "0"),
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.stop_grace_period", "10s"),
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.user", ""),
@@ -852,7 +894,7 @@ func TestAccDockerService_updateMultiplePropertiesConverge(t *testing.T) {
 				),
 			},
 			{
-				Config: fmt.Sprintf(updateMultiplePropertiesConfigConverge, configData2, secretData2, image2, hosts2, healthcheckInterval2, healthcheckTimeout2, logging2, replicas2, portsSpec2),
+				Config: fmt.Sprintf(updateMultiplePropertiesConfigConverge, configData2, secretData2, image2, mounts2, hosts2, healthcheckInterval2, healthcheckTimeout2, logging2, replicas2, portsSpec2),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr("docker_service.foo", "id", serviceIDRegex),
 					resource.TestCheckResourceAttr("docker_service.foo", "name", "tftest-fnf-service-up-crihiadr"),
@@ -888,6 +930,7 @@ func TestAccDockerService_updateMultiplePropertiesConverge(t *testing.T) {
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.hosts.575059346.ip", "10.0.2.2"),
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.isolation", "default"),
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.labels.%", "0"),
+					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.mounts.#", "2"),
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.privileges.#", "0"),
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.stop_grace_period", "10s"),
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.user", ""),
@@ -899,7 +942,7 @@ func TestAccDockerService_updateMultiplePropertiesConverge(t *testing.T) {
 				),
 			},
 			{
-				Config: fmt.Sprintf(updateMultiplePropertiesConfigConverge, configData3, secretData3, image3, hosts3, healthcheckInterval3, healthcheckTimeout3, logging3, replicas3, portsSpec3),
+				Config: fmt.Sprintf(updateMultiplePropertiesConfigConverge, configData3, secretData3, image3, mounts3, hosts3, healthcheckInterval3, healthcheckTimeout3, logging3, replicas3, portsSpec3),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr("docker_service.foo", "id", serviceIDRegex),
 					resource.TestCheckResourceAttr("docker_service.foo", "name", "tftest-fnf-service-up-crihiadr"),
@@ -935,6 +978,7 @@ func TestAccDockerService_updateMultiplePropertiesConverge(t *testing.T) {
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.hosts.575059346.ip", "10.0.2.2"),
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.isolation", "default"),
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.labels.%", "0"),
+					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.mounts.#", "2"),
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.privileges.#", "0"),
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.stop_grace_period", "10s"),
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.user", ""),
@@ -1123,6 +1167,14 @@ provider "docker" {
 	}
 }
 
+resource "docker_volume" "foo" {
+	name = "tftest-volume"
+}
+
+resource "docker_volume" "foo2" {
+	name = "tftest-volume2"
+}
+
 resource "docker_config" "service_config" {
 	name 			 = "tftest-myconfig-${uuid()}"
 	data 			 = "%s"
@@ -1150,6 +1202,10 @@ resource "docker_service" "foo" {
 	task_spec {
 		container_spec {
 			image   = "%s"
+
+			mounts = [
+				%s
+			]
 
 			hosts = [
 				%s

--- a/docker/resource_docker_service_test.go
+++ b/docker/resource_docker_service_test.go
@@ -1211,7 +1211,7 @@ resource "docker_service" "foo" {
 
 	converge_config {
 		delay    = "7s"
-		timeout  = "10m"
+		timeout  = "6m"
 	}
 }
 `

--- a/docker/resource_docker_service_test.go
+++ b/docker/resource_docker_service_test.go
@@ -813,10 +813,10 @@ func TestAccDockerService_updateMultiplePropertiesConverge(t *testing.T) {
 					resource.TestCheckResourceAttr("docker_service.foo", "name", "tftest-fnf-service-up-crihiadr"),
 					resource.TestMatchResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.image", regexp.MustCompile(`127.0.0.1:15000/tftest-service:v1@sha256.*`)),
 					resource.TestCheckResourceAttr("docker_service.foo", "mode.0.replicated.0.replicas", strconv.Itoa(replicas)),
-					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.parallelism", "1"),
-					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.delay", "1s"),
+					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.parallelism", "2"),
+					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.delay", "3s"),
 					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.failure_action", "pause"),
-					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.monitor", "1s"),
+					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.monitor", "3s"),
 					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.max_failure_ratio", "0.1"),
 					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.order", "start-first"),
 					resource.TestCheckResourceAttr("docker_service.foo", "endpoint_spec.0.ports.#", "1"),
@@ -858,10 +858,10 @@ func TestAccDockerService_updateMultiplePropertiesConverge(t *testing.T) {
 					resource.TestCheckResourceAttr("docker_service.foo", "name", "tftest-fnf-service-up-crihiadr"),
 					resource.TestMatchResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.image", regexp.MustCompile(`127.0.0.1:15000/tftest-service:v2.*`)),
 					resource.TestCheckResourceAttr("docker_service.foo", "mode.0.replicated.0.replicas", strconv.Itoa(replicas2)),
-					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.parallelism", "1"),
-					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.delay", "1s"),
+					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.parallelism", "2"),
+					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.delay", "3s"),
 					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.failure_action", "pause"),
-					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.monitor", "1s"),
+					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.monitor", "3s"),
 					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.max_failure_ratio", "0.1"),
 					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.order", "start-first"),
 					resource.TestCheckResourceAttr("docker_service.foo", "endpoint_spec.0.ports.#", "2"),
@@ -905,10 +905,10 @@ func TestAccDockerService_updateMultiplePropertiesConverge(t *testing.T) {
 					resource.TestCheckResourceAttr("docker_service.foo", "name", "tftest-fnf-service-up-crihiadr"),
 					resource.TestMatchResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.image", regexp.MustCompile(`127.0.0.1:15000/tftest-service:v2.*`)),
 					resource.TestCheckResourceAttr("docker_service.foo", "mode.0.replicated.0.replicas", strconv.Itoa(replicas3)),
-					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.parallelism", "1"),
-					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.delay", "1s"),
+					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.parallelism", "2"),
+					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.delay", "3s"),
 					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.failure_action", "pause"),
-					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.monitor", "1s"),
+					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.monitor", "3s"),
 					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.max_failure_ratio", "0.1"),
 					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.order", "start-first"),
 					resource.TestCheckResourceAttr("docker_service.foo", "endpoint_spec.0.ports.#", "2"),
@@ -1195,10 +1195,10 @@ resource "docker_service" "foo" {
 	}
 
 	update_config {
-		parallelism       = 1
-		delay             = "1s"
+		parallelism       = 2
+		delay             = "3s"
 		failure_action    = "pause"
-		monitor           = "1s"
+		monitor           = "3s"
 		max_failure_ratio = "0.1"
 		order             = "start-first"
 	}

--- a/docker/resource_docker_service_test.go
+++ b/docker/resource_docker_service_test.go
@@ -815,9 +815,9 @@ func TestAccDockerService_updateMultiplePropertiesConverge(t *testing.T) {
 					resource.TestCheckResourceAttr("docker_service.foo", "mode.0.replicated.0.replicas", strconv.Itoa(replicas)),
 					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.parallelism", "2"),
 					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.delay", "3s"),
-					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.failure_action", "pause"),
+					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.failure_action", "continue"),
 					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.monitor", "3s"),
-					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.max_failure_ratio", "0.1"),
+					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.max_failure_ratio", "0.5"),
 					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.order", "start-first"),
 					resource.TestCheckResourceAttr("docker_service.foo", "endpoint_spec.0.ports.#", "1"),
 					resource.TestCheckResourceAttr("docker_service.foo", "endpoint_spec.0.ports.3541714906.target_port", "8080"),
@@ -860,9 +860,9 @@ func TestAccDockerService_updateMultiplePropertiesConverge(t *testing.T) {
 					resource.TestCheckResourceAttr("docker_service.foo", "mode.0.replicated.0.replicas", strconv.Itoa(replicas2)),
 					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.parallelism", "2"),
 					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.delay", "3s"),
-					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.failure_action", "pause"),
+					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.failure_action", "continue"),
 					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.monitor", "3s"),
-					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.max_failure_ratio", "0.1"),
+					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.max_failure_ratio", "0.5"),
 					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.order", "start-first"),
 					resource.TestCheckResourceAttr("docker_service.foo", "endpoint_spec.0.ports.#", "2"),
 					resource.TestCheckResourceAttr("docker_service.foo", "endpoint_spec.0.ports.3541714906.target_port", "8080"),
@@ -907,9 +907,9 @@ func TestAccDockerService_updateMultiplePropertiesConverge(t *testing.T) {
 					resource.TestCheckResourceAttr("docker_service.foo", "mode.0.replicated.0.replicas", strconv.Itoa(replicas3)),
 					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.parallelism", "2"),
 					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.delay", "3s"),
-					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.failure_action", "pause"),
+					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.failure_action", "continue"),
 					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.monitor", "3s"),
-					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.max_failure_ratio", "0.1"),
+					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.max_failure_ratio", "0.5"),
 					resource.TestCheckResourceAttr("docker_service.foo", "update_config.0.order", "start-first"),
 					resource.TestCheckResourceAttr("docker_service.foo", "endpoint_spec.0.ports.#", "2"),
 					resource.TestCheckResourceAttr("docker_service.foo", "endpoint_spec.0.ports.3541714906.target_port", "8080"),
@@ -1197,9 +1197,9 @@ resource "docker_service" "foo" {
 	update_config {
 		parallelism       = 2
 		delay             = "3s"
-		failure_action    = "pause"
+		failure_action    = "continue"
 		monitor           = "3s"
-		max_failure_ratio = "0.1"
+		max_failure_ratio = "0.5"
 		order             = "start-first"
 	}
 

--- a/docker/resource_docker_service_test.go
+++ b/docker/resource_docker_service_test.go
@@ -1211,7 +1211,7 @@ resource "docker_service" "foo" {
 
 	converge_config {
 		delay    = "7s"
-		timeout  = "10m"
+		timeout  = "2m"
 	}
 }
 `

--- a/docker/resource_docker_service_test.go
+++ b/docker/resource_docker_service_test.go
@@ -1211,7 +1211,7 @@ resource "docker_service" "foo" {
 
 	converge_config {
 		delay    = "7s"
-		timeout  = "1m"
+		timeout  = "10m"
 	}
 }
 `

--- a/docker/resource_docker_service_test.go
+++ b/docker/resource_docker_service_test.go
@@ -685,7 +685,7 @@ func TestAccDockerService_ConflictingGlobalModeAndConverge(t *testing.T) {
 // Converging tests
 func TestAccDockerService_privateImageConverge(t *testing.T) {
 	registry := "127.0.0.1:15000"
-	image := "127.0.0.1:15000/tftest-service"
+	image := "127.0.0.1:15000/tftest-service:v1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -723,7 +723,7 @@ func TestAccDockerService_privateImageConverge(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr("docker_service.bar", "id", serviceIDRegex),
 					resource.TestCheckResourceAttr("docker_service.bar", "name", "tftest-service-bar"),
-					resource.TestMatchResourceAttr("docker_service.bar", "task_spec.0.container_spec.0.image", regexp.MustCompile(`127.0.0.1:15000/tftest-service:latest@sha256.*`)),
+					resource.TestMatchResourceAttr("docker_service.bar", "task_spec.0.container_spec.0.image", regexp.MustCompile(`127.0.0.1:15000/tftest-service:v1@sha256.*`)),
 				),
 			},
 		},
@@ -736,20 +736,6 @@ func TestAccDockerService_updateMultiplePropertiesConverge(t *testing.T) {
 	configData := "ewogICJwcmVmaXgiOiAiMTIzIgp9"
 	secretData := "ewogICJrZXkiOiAiUVdFUlRZIgp9"
 	image := "127.0.0.1:15000/tftest-service:v1"
-	mounts := `
-		{
-			source = "${docker_volume.foo.name}"
-			target = "/mount/test"
-			type   = "volume"
-			read_only = true
-			volume_options {
-				labels {
-					env = "dev"
-					terraform = "true"
-				}
-			}
-		}
-	`
 	hosts := `
 		{
 			host = "testhost"
@@ -779,32 +765,6 @@ func TestAccDockerService_updateMultiplePropertiesConverge(t *testing.T) {
 	secretData2 := "ewogICJrZXkiOiAiUVdFUlRZIgp9" // UPDATED to YXCVB
 	image2 := "127.0.0.1:15000/tftest-service:v2"
 	healthcheckInterval2 := "2s"
-	mounts2 := `
-		{
-			source = "${docker_volume.foo.name}"
-			target = "/mount/test"
-			type   = "volume"
-			read_only = true
-			volume_options {
-				labels {
-					env = "dev"
-					terraform = "true"
-				}
-			}
-		},
-		{
-			source = "${docker_volume.foo2.name}"
-			target = "/mount/test2"
-			type   = "volume"
-			read_only = true
-			volume_options {
-				labels {
-					env = "dev"
-					terraform = "true"
-				}
-			}
-		}
-	`
 	hosts2 := `
 		{
 			host = "testhost2"
@@ -836,7 +796,6 @@ func TestAccDockerService_updateMultiplePropertiesConverge(t *testing.T) {
 	configData3 := configData2
 	secretData3 := secretData2
 	image3 := image2
-	mounts3 := mounts2
 	hosts3 := hosts2
 	logging3 := logging2
 	healthcheckInterval3 := healthcheckInterval2
@@ -848,7 +807,7 @@ func TestAccDockerService_updateMultiplePropertiesConverge(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(updateMultiplePropertiesConfigConverge, configData, secretData, image, mounts, hosts, healthcheckInterval, healthcheckTimeout, logging, replicas, portsSpec),
+				Config: fmt.Sprintf(updateMultiplePropertiesConfigConverge, configData, secretData, image, hosts, healthcheckInterval, healthcheckTimeout, logging, replicas, portsSpec),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr("docker_service.foo", "id", serviceIDRegex),
 					resource.TestCheckResourceAttr("docker_service.foo", "name", "tftest-fnf-service-up-crihiadr"),
@@ -882,7 +841,6 @@ func TestAccDockerService_updateMultiplePropertiesConverge(t *testing.T) {
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.hosts.1878413705.ip", "10.0.1.0"),
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.isolation", "default"),
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.labels.%", "0"),
-					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.mounts.#", "1"),
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.privileges.#", "0"),
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.stop_grace_period", "10s"),
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.user", ""),
@@ -894,7 +852,7 @@ func TestAccDockerService_updateMultiplePropertiesConverge(t *testing.T) {
 				),
 			},
 			{
-				Config: fmt.Sprintf(updateMultiplePropertiesConfigConverge, configData2, secretData2, image2, mounts2, hosts2, healthcheckInterval2, healthcheckTimeout2, logging2, replicas2, portsSpec2),
+				Config: fmt.Sprintf(updateMultiplePropertiesConfigConverge, configData2, secretData2, image2, hosts2, healthcheckInterval2, healthcheckTimeout2, logging2, replicas2, portsSpec2),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr("docker_service.foo", "id", serviceIDRegex),
 					resource.TestCheckResourceAttr("docker_service.foo", "name", "tftest-fnf-service-up-crihiadr"),
@@ -930,7 +888,6 @@ func TestAccDockerService_updateMultiplePropertiesConverge(t *testing.T) {
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.hosts.575059346.ip", "10.0.2.2"),
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.isolation", "default"),
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.labels.%", "0"),
-					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.mounts.#", "2"),
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.privileges.#", "0"),
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.stop_grace_period", "10s"),
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.user", ""),
@@ -942,7 +899,7 @@ func TestAccDockerService_updateMultiplePropertiesConverge(t *testing.T) {
 				),
 			},
 			{
-				Config: fmt.Sprintf(updateMultiplePropertiesConfigConverge, configData3, secretData3, image3, mounts3, hosts3, healthcheckInterval3, healthcheckTimeout3, logging3, replicas3, portsSpec3),
+				Config: fmt.Sprintf(updateMultiplePropertiesConfigConverge, configData3, secretData3, image3, hosts3, healthcheckInterval3, healthcheckTimeout3, logging3, replicas3, portsSpec3),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr("docker_service.foo", "id", serviceIDRegex),
 					resource.TestCheckResourceAttr("docker_service.foo", "name", "tftest-fnf-service-up-crihiadr"),
@@ -978,7 +935,6 @@ func TestAccDockerService_updateMultiplePropertiesConverge(t *testing.T) {
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.hosts.575059346.ip", "10.0.2.2"),
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.isolation", "default"),
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.labels.%", "0"),
-					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.mounts.#", "2"),
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.privileges.#", "0"),
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.stop_grace_period", "10s"),
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.user", ""),
@@ -1167,14 +1123,6 @@ provider "docker" {
 	}
 }
 
-resource "docker_volume" "foo" {
-	name = "tftest-volume"
-}
-
-resource "docker_volume" "foo2" {
-	name = "tftest-volume2"
-}
-
 resource "docker_config" "service_config" {
 	name 			 = "tftest-myconfig-${uuid()}"
 	data 			 = "%s"
@@ -1202,10 +1150,6 @@ resource "docker_service" "foo" {
 	task_spec {
 		container_spec {
 			image   = "%s"
-
-			mounts = [
-				%s
-			]
 
 			hosts = [
 				%s
@@ -1267,7 +1211,7 @@ resource "docker_service" "foo" {
 
 	converge_config {
 		delay    = "7s"
-		timeout  = "3m"
+		timeout  = "1m"
 	}
 }
 `

--- a/docker/resource_docker_service_test.go
+++ b/docker/resource_docker_service_test.go
@@ -1211,7 +1211,7 @@ resource "docker_service" "foo" {
 
 	converge_config {
 		delay    = "7s"
-		timeout  = "6m"
+		timeout  = "10m"
 	}
 }
 `

--- a/scripts/runAccTests.sh
+++ b/scripts/runAccTests.sh
@@ -49,10 +49,10 @@ setup() {
 
 run() {
   go clean -testcache
-  #TF_ACC=1 go test ./docker -v -timeout 120m
+  TF_ACC=1 go test ./docker -v -timeout 120m
   
   # for a single test comment the previous line and uncomment the next line
-  TF_LOG=DEBUG TF_ACC=1 go test -v ./docker -run ^TestAccDockerService_updateMultiplePropertiesConverge$ -timeout 360s
+  #TF_LOG=DEBUG TF_ACC=1 go test -v ./docker -run ^TestAccDockerService_updateMultiplePropertiesConverge$ -timeout 360s
   
   # keep the return value for the scripts to fail and clean properly
   return $?

--- a/scripts/runAccTests.sh
+++ b/scripts/runAccTests.sh
@@ -45,10 +45,6 @@ setup() {
   done
   # Remove images from host machine before starting the tests
   for i in $(docker images -aq 127.0.0.1:15000/tftest-service); do docker rmi -f "$i"; done
-
-  # debug
-  cat ~/.docker/config.json
-  docker images
 }
 
 run() {

--- a/scripts/runAccTests.sh
+++ b/scripts/runAccTests.sh
@@ -52,7 +52,7 @@ run() {
   #TF_ACC=1 go test ./docker -v -timeout 120m
   
   # for a single test comment the previous line and uncomment the next line
-  TF_LOG=DEBUG TF_ACC=1 go test -v ./docker -run ^TestAccDockerService_updateMultiplePropertiesConverge$ -timeout 600s
+  TF_LOG=DEBUG TF_ACC=1 go test -v ./docker -run ^TestAccDockerService_updateMultiplePropertiesConverge$ -timeout 360s
   
   # keep the return value for the scripts to fail and clean properly
   return $?

--- a/scripts/runAccTests.sh
+++ b/scripts/runAccTests.sh
@@ -49,10 +49,10 @@ setup() {
 
 run() {
   go clean -testcache
-  TF_ACC=1 go test ./docker -v -timeout 120m
+  #TF_ACC=1 go test ./docker -v -timeout 120m
   
   # for a single test comment the previous line and uncomment the next line
-  #TF_LOG=INFO TF_ACC=1 go test -v ./docker -run ^TestAccDockerImage_data_private_config_file$ -timeout 360s
+  TF_LOG=INFO TF_ACC=1 go test -v ./docker -run ^TestAccDockerService_updateMultiplePropertiesConverge$ -timeout 360s
   
   # keep the return value for the scripts to fail and clean properly
   return $?

--- a/scripts/runAccTests.sh
+++ b/scripts/runAccTests.sh
@@ -56,7 +56,7 @@ run() {
   #TF_ACC=1 go test ./docker -v -timeout 120m
   
   # for a single test comment the previous line and uncomment the next line
-  TF_LOG=INFO TF_ACC=1 go test -v ./docker -run ^TestAccDockerService_updateMultiplePropertiesConverge$ -timeout 600s
+  TF_LOG=DEBUG TF_ACC=1 go test -v ./docker -run ^TestAccDockerService_updateMultiplePropertiesConverge$ -timeout 600s
   
   # keep the return value for the scripts to fail and clean properly
   return $?

--- a/scripts/runAccTests.sh
+++ b/scripts/runAccTests.sh
@@ -45,6 +45,10 @@ setup() {
   done
   # Remove images from host machine before starting the tests
   for i in $(docker images -aq 127.0.0.1:15000/tftest-service); do docker rmi -f "$i"; done
+
+  # debug
+  cat ~/.docker/config.json
+  docker images
 }
 
 run() {
@@ -52,7 +56,7 @@ run() {
   #TF_ACC=1 go test ./docker -v -timeout 120m
   
   # for a single test comment the previous line and uncomment the next line
-  TF_LOG=INFO TF_ACC=1 go test -v ./docker -run ^TestAccDockerService_updateMultiplePropertiesConverge$ -timeout 360s
+  TF_LOG=INFO TF_ACC=1 go test -v ./docker -run ^TestAccDockerService_updateMultiplePropertiesConverge$ -timeout 600s
   
   # keep the return value for the scripts to fail and clean properly
   return $?


### PR DESCRIPTION
Several tests run fine locally and on `travis` but not in the official CI tool which builds and releases the provider. This is the reason why several tests have to be adapted.

- pin version to `v1` on service test with private image
- fixes flaky service update test by adding retry for fetch the registry auth