### PR TITLE
Fix no-op in container when all 'ports' blocks are deleted.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## 2.1.1 (Unreleased)
+
+BUG FIXES
+* Fixes 'No changes' for containers when all port blocks have been removed ([#167](https://github.com/terraform-providers/terraform-provider-docker/issues/167))
+
 ## 2.1.0 (July 19, 2019)
 
 IMPROVEMENTS
@@ -12,7 +16,7 @@ DOC
 
 BREAKING CHANGES
 * Updates to Terraform `v0.12` [[#144](https://github.com/terraform-providers/terraform-provider-docker/issues/144)] and ([#150](https://github.com/terraform-providers/terraform-provider-docker/pull/150))
-  
+
 IMPROVEMENTS
 * Refactors test setup ([#156](https://github.com/terraform-providers/terraform-provider-docker/pull/156))
 * Fixes flaky acceptance tests ([#154](https://github.com/terraform-providers/terraform-provider-docker/pull/154))
@@ -34,7 +38,7 @@ BUG FIXES
 
 BUG FIXES
 * Fixes no more 'force new resource' for container ports when
-there are no changes. This was caused to the ascending order. See [[#110](https://github.com/terraform-providers/terraform-provider-docker/issues/110)] 
+there are no changes. This was caused to the ascending order. See [[#110](https://github.com/terraform-providers/terraform-provider-docker/issues/110)]
 for details and ([#115](https://github.com/terraform-providers/terraform-provider-docker/pull/115))
 * Normalize blank port IP's to 0.0.0.0 ([#128](https://github.com/terraform-providers/terraform-provider-docker/pull/128))
 
@@ -51,7 +55,7 @@ DOCS
 ## 1.1.0 (October 30, 2018)
 
 IMPROVEMENTS
-* Adds labels for `network`, `volume` and `secret` to support docker stacks. [[#92](https://github.com/terraform-providers/terraform-provider-docker/pull/92)] 
+* Adds labels for `network`, `volume` and `secret` to support docker stacks. [[#92](https://github.com/terraform-providers/terraform-provider-docker/pull/92)]
 * Adds `rm` and `attach` options to execute short-lived containers ([#43](https://github.com/terraform-providers/terraform-provider-docker/issues/43)] and [[#106](https://github.com/terraform-providers/terraform-provider-docker/pull/106))
 * Adds container healthcheck([#93](https://github.com/terraform-providers/terraform-provider-docker/pull/93))
 * Adds the docker container start flag ([#62](https://github.com/terraform-providers/terraform-provider-docker/issues/62)] and [[#94](https://github.com/terraform-providers/terraform-provider-docker/pull/94))

--- a/docker/resource_docker_container.go
+++ b/docker/resource_docker_container.go
@@ -718,6 +718,10 @@ func resourceDockerContainer() *schema.Resource {
 
 func suppressIfPortsDidNotChangeForMigrationV0ToV1() schema.SchemaDiffSuppressFunc {
 	return func(k, old, new string, d *schema.ResourceData) bool {
+		if k == "ports.#" && old != new {
+			log.Printf("[DEBUG] suppress diff ports: old and new don't have the same length")
+			return false
+		}
 		portsOldRaw, portsNewRaw := d.GetChange("ports")
 		portsOld := portsOldRaw.([]interface{})
 		portsNew := portsNewRaw.([]interface{})

--- a/docker/resource_docker_container_test.go
+++ b/docker/resource_docker_container_test.go
@@ -717,6 +717,14 @@ func TestAccDockerContainer_port(t *testing.T) {
 					resource.TestCheckResourceAttr("docker_container.foo", "ports.0.external", "32787"),
 				),
 			},
+			{
+				Config: testAccDockerContainerConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccContainerRunning("docker_container.foo", &c),
+					resource.TestCheckResourceAttr("docker_container.foo", "name", "tf-test"),
+					resource.TestCheckResourceAttr("docker_container.foo", "ports.#", "0"),
+				),
+			},
 		},
 	})
 }


### PR DESCRIPTION
Fixes #167.

`d.GetChange` returns the same elements if all the blocks were removed, so we have to look at the values of `ports.#` also to identify if new resource should be forced. Existing logic because it creates a more accurate `plan` when existing port values are just modified.