### PR TITLE
Add support for sysctls

### DIFF
--- a/docker/resource_docker_container.go
+++ b/docker/resource_docker_container.go
@@ -712,6 +712,12 @@ func resourceDockerContainer() *schema.Resource {
 					},
 				},
 			},
+
+			"sysctls": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }

--- a/docker/resource_docker_container_funcs.go
+++ b/docker/resource_docker_container_funcs.go
@@ -304,6 +304,10 @@ func resourceDockerContainerCreate(d *schema.ResourceData, meta interface{}) err
 		hostConfig.PidMode = container.PidMode(v.(string))
 	}
 
+	if v, ok := d.GetOk("sysctls"); ok {
+		hostConfig.Sysctls = mapTypeMapValsToString(v.(map[string]interface{}))
+	}
+
 	var retContainer container.ContainerCreateCreatedBody
 
 	if retContainer, err = client.ContainerCreate(context.Background(), config, hostConfig, networkingConfig, d.Get("name").(string)); err != nil {

--- a/website/docs/r/container.html.markdown
+++ b/website/docs/r/container.html.markdown
@@ -105,7 +105,7 @@ data is stored in them. See [the docker documentation][linkdoc] for more details
 * `pid_mode` - (Optional, string) The PID (Process) Namespace mode for the container. Either `container:<name|id>` or `host`.
 * `userns_mode` - (Optional, string) Sets the usernamespace mode for the container when usernamespace remapping option is enabled.
 * `healthcheck` - (Optional, block) See [Healthcheck](#healthcheck) below for details.
-
+* `sysctls` - (Optional, map) A map of kernel parameters (sysctls) to set in the container.
 <a id="capabilities"></a>
 ### Capabilities
 


### PR DESCRIPTION
This PR adds support for configuring [namespaced kernel parameters](https://docs.docker.com/engine/reference/commandline/run/#configure-namespaced-kernel-parameters-sysctls-at-runtime) to `resource/docker_container`.