### PR TITLE
fix for destroy_grace_seconds is not adhered to #174

### DIFF
--- a/docker/resource_docker_container_funcs.go
+++ b/docker/resource_docker_container_funcs.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"math/rand"
 	"os"
 	"sort"
 	"strconv"
@@ -569,9 +568,8 @@ func resourceDockerContainerDelete(d *schema.ResourceData, meta interface{}) err
 	if !d.Get("attach").(bool) {
 		// Stop the container before removing if destroy_grace_seconds is defined
 		if d.Get("destroy_grace_seconds").(int) > 0 {
-			mapped := int32(d.Get("destroy_grace_seconds").(int))
-			timeoutInSeconds := rand.Int31n(mapped)
-			timeout := time.Duration(time.Duration(timeoutInSeconds) * time.Second)
+			timeout := time.Duration(int32(d.Get("destroy_grace_seconds").(int))) * time.Second
+
 			if err := client.ContainerStop(context.Background(), d.Id(), &timeout); err != nil {
 				return fmt.Errorf("Error stopping container %s: %s", d.Id(), err)
 			}


### PR DESCRIPTION
Fix for destroy_grace_seconds - minor bugfix to remove randomness.

I've had a crack at setting up a test for this in testacc (there is currently no test), but can't seem to work it out as I'm fairly new to golang and the terraform testing framework. In the testing framework I can get the container to go into a shutdown state, but not with the grace period set so the container seems to run forever and the test fails.

This has been manually tested with a 18000 second (5 hours) timeout. See this gist for output https://gist.github.com/laurieodgers/1441a8e9069bf9ff8b0df25dcfd7eafa