### PR TITLE
Add `shm_size' attribute for `docker_container' resource.

### DIFF
--- a/docker/resource_docker_container.go
+++ b/docker/resource_docker_container.go
@@ -548,6 +548,13 @@ func resourceDockerContainer() *schema.Resource {
 				ValidateFunc: validateIntegerGeqThan(-1),
 			},
 
+			"shm_size": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateIntegerGeqThan(0),
+			},
+
 			"cpu_shares": {
 				Type:         schema.TypeInt,
 				Optional:     true,

--- a/docker/resource_docker_container_funcs.go
+++ b/docker/resource_docker_container_funcs.go
@@ -281,6 +281,10 @@ func resourceDockerContainerCreate(d *schema.ResourceData, meta interface{}) err
 		hostConfig.MemorySwap = swap
 	}
 
+	if v, ok := d.GetOk("shm_size"); ok {
+		hostConfig.ShmSize = int64(v.(int)) * 1024 * 1024
+	}
+
 	if v, ok := d.GetOk("cpu_shares"); ok {
 		hostConfig.CPUShares = int64(v.(int))
 	}

--- a/docker/resource_docker_container_test.go
+++ b/docker/resource_docker_container_test.go
@@ -329,6 +329,10 @@ func TestAccDockerContainer_customized(t *testing.T) {
 			return fmt.Errorf("Container has wrong memory swap setting: %d\n\r\tPlease check that you machine supports memory swap (you can do that by running 'docker info' command).", c.HostConfig.MemorySwap)
 		}
 
+		if c.HostConfig.ShmSize != (128 * 1024 * 1024) {
+			return fmt.Errorf("Container has wrong shared memory setting: %d", c.HostConfig.ShmSize)
+		}
+
 		if c.HostConfig.CPUShares != 32 {
 			return fmt.Errorf("Container has wrong cpu shares setting: %d", c.HostConfig.CPUShares)
 		}
@@ -1387,6 +1391,7 @@ resource "docker_container" "foo" {
 	destroy_grace_seconds = 10
 	max_retry_count = 5
 	memory = 512
+	shm_size = 128
 	memory_swap = 2048
 	cpu_shares = 32
 	cpu_set = "0-1"

--- a/website/docs/r/container.html.markdown
+++ b/website/docs/r/container.html.markdown
@@ -88,6 +88,7 @@ data is stored in them. See [the docker documentation][linkdoc] for more details
 * `memory` - (Optional, int) The memory limit for the container in MBs.
 * `memory_swap` - (Optional, int) The total memory limit (memory + swap) for the
   container in MBs. This setting may compute to `-1` after `terraform apply` if the target host doesn't support memory swap, when that is the case docker will use a soft limitation.
+* `shm_size` - (Optional, int) Size of `/dev/shm` in MBs.
 * `cpu_shares` - (Optional, int) CPU shares (relative weight) for the container.
 * `cpu_set` - (Optional, string) A comma-separated list or hyphen-separated range of CPUs a container can use, e.g. `0-1`.
 * `log_driver` - (Optional, string) The logging driver to use for the container.
@@ -149,7 +150,7 @@ supports the following:
   * `labels` - (Optional, map of key/value pairs) Adding labels.
   * `driver_options` - (Optional, map of key/value pairs) Options for the driver.
 * `tmpfs_options` - (Optional, map) Optional configuration for the `tmpf` type.
-  * `size_bytes` - (Optional, int) The size for the tmpfs mount in bytes. 
+  * `size_bytes` - (Optional, int) The size for the tmpfs mount in bytes.
   * `mode` - (Optional, int) The permission mode for the tmpfs mount in an integer.
 
 <a id="ports-1"></a>


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-docker/issues/164.

@mavogel - Can you please review?