### PR TITLE
fix: service env truncation for multiple delimiters

### DIFF
--- a/docker/resource_docker_service_test.go
+++ b/docker/resource_docker_service_test.go
@@ -237,6 +237,7 @@ func TestAccDockerService_fullSpec(t *testing.T) {
 
 							env = {
 								MYFOO = "BAR"
+								URI   = "/api-call?param1=value1"
 							}
 
 							dir    = "/root"
@@ -398,6 +399,7 @@ func TestAccDockerService_fullSpec(t *testing.T) {
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.args.0", "-las"),
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.hostname", "my-fancy-service"),
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.env.MYFOO", "BAR"),
+					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.env.URI", "/api-call?param1=value1"),
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.dir", "/root"),
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.user", "root"),
 					resource.TestCheckResourceAttr("docker_service.foo", "task_spec.0.container_spec.0.groups.0", "docker"),

--- a/docker/structures_service.go
+++ b/docker/structures_service.go
@@ -516,14 +516,16 @@ func newStringSet(f schema.SchemaSetFunc, in []string) *schema.Set {
 	return schema.NewSet(f, out)
 }
 
-// mapStringSliceToMap maps a slice with '='  delimiter to as map: e.g. 'foo=bar' -> foo = "bar"
+// mapStringSliceToMap maps a slice with '='  delimiter to as map: e.g.
+// - 'foo=bar' -> foo = "bar"
+// - 'foo=bar?p=baz' -> foo = "bar?p=baz"
 func mapStringSliceToMap(in []string) map[string]string {
 	mapped := make(map[string]string, len(in))
 	for _, v := range in {
 		if len(v) > 0 {
 			splitted := strings.Split(v, "=")
 			key := splitted[0]
-			value := splitted[1]
+			value := strings.Join(splitted[1:], "=")
 			mapped[key] = value
 		}
 	}


### PR DESCRIPTION
Fixes #121 by preserving the whole remaining substring even if it contains the delimiter `=`