### PR TITLE
fix: binary upload as base 64 content

### DIFF
--- a/docker/resource_docker_container.go
+++ b/docker/resource_docker_container.go
@@ -662,15 +662,16 @@ func resourceDockerContainer() *schema.Resource {
 							Optional: true,
 							// This is intentional. The container is mutated once, and never updated later.
 							// New configuration forces a new deployment, even with the same binaries.
-							ForceNew:      true,
-							ConflictsWith: []string{"upload.content_base64"},
+							ForceNew: true,
+							// ConflictsWith in lists/sets is not supported yet: https://github.com/hashicorp/terraform-plugin-sdk/issues/71
+							// ConflictsWith: []string{"upload.content_base64"},
 						},
 						"content_base64": {
-							Type:          schema.TypeString,
-							Optional:      true,
-							ForceNew:      true,
-							ValidateFunc:  validateStringIsBase64Encoded(),
-							ConflictsWith: []string{"upload.content"},
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validateStringIsBase64Encoded(),
+							// ConflictsWith: []string{"upload.content"},
 						},
 						"file": {
 							Type:     schema.TypeString,

--- a/docker/resource_docker_container.go
+++ b/docker/resource_docker_container.go
@@ -663,15 +663,12 @@ func resourceDockerContainer() *schema.Resource {
 							// This is intentional. The container is mutated once, and never updated later.
 							// New configuration forces a new deployment, even with the same binaries.
 							ForceNew: true,
-							// ConflictsWith in lists/sets is not supported yet: https://github.com/hashicorp/terraform-plugin-sdk/issues/71
-							// ConflictsWith: []string{"upload.content_base64"},
 						},
 						"content_base64": {
 							Type:         schema.TypeString,
 							Optional:     true,
 							ForceNew:     true,
 							ValidateFunc: validateStringIsBase64Encoded(),
-							// ConflictsWith: []string{"upload.content"},
 						},
 						"file": {
 							Type:     schema.TypeString,

--- a/docker/resource_docker_container.go
+++ b/docker/resource_docker_container.go
@@ -659,10 +659,18 @@ func resourceDockerContainer() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"content": {
 							Type:     schema.TypeString,
-							Required: true,
+							Optional: true,
 							// This is intentional. The container is mutated once, and never updated later.
 							// New configuration forces a new deployment, even with the same binaries.
-							ForceNew: true,
+							ForceNew:      true,
+							ConflictsWith: []string{"upload.content_base64"},
+						},
+						"content_base64": {
+							Type:          schema.TypeString,
+							Optional:      true,
+							ForceNew:      true,
+							ValidateFunc:  validateStringIsBase64Encoded(),
+							ConflictsWith: []string{"upload.content"},
 						},
 						"file": {
 							Type:     schema.TypeString,

--- a/docker/resource_docker_container_funcs.go
+++ b/docker/resource_docker_container_funcs.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bufio"
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -382,6 +383,18 @@ func resourceDockerContainerCreate(d *schema.ResourceData, meta interface{}) err
 		var mode int64
 		for _, upload := range v.(*schema.Set).List() {
 			content := upload.(map[string]interface{})["content"].(string)
+			contentBase64 := upload.(map[string]interface{})["content_base64"].(string)
+			if content == "" && contentBase64 == "" {
+				return fmt.Errorf("Error with upload content: neither 'content', nor 'content_base64' was set")
+			}
+			var contentToUpload string
+			if content != "" {
+				contentToUpload = content
+			}
+			if contentBase64 != "" {
+				decoded, _ := base64.StdEncoding.DecodeString(contentBase64)
+				contentToUpload = string(decoded)
+			}
 			file := upload.(map[string]interface{})["file"].(string)
 			executable := upload.(map[string]interface{})["executable"].(bool)
 
@@ -395,12 +408,12 @@ func resourceDockerContainerCreate(d *schema.ResourceData, meta interface{}) err
 			hdr := &tar.Header{
 				Name: file,
 				Mode: mode,
-				Size: int64(len(content)),
+				Size: int64(len(contentToUpload)),
 			}
 			if err := tw.WriteHeader(hdr); err != nil {
 				return fmt.Errorf("Error creating tar archive: %s", err)
 			}
-			if _, err := tw.Write([]byte(content)); err != nil {
+			if _, err := tw.Write([]byte(contentToUpload)); err != nil {
 				return fmt.Errorf("Error creating tar archive: %s", err)
 			}
 			if err := tw.Close(); err != nil {

--- a/docker/resource_docker_container_funcs.go
+++ b/docker/resource_docker_container_funcs.go
@@ -387,6 +387,9 @@ func resourceDockerContainerCreate(d *schema.ResourceData, meta interface{}) err
 			if content == "" && contentBase64 == "" {
 				return fmt.Errorf("Error with upload content: neither 'content', nor 'content_base64' was set")
 			}
+			if content != "" && contentBase64 != "" {
+				return fmt.Errorf("Error with upload content: only one of 'content' or 'content_base64' can be specified")
+			}
 			var contentToUpload string
 			if content != "" {
 				contentToUpload = content

--- a/docker/resource_docker_container_test.go
+++ b/docker/resource_docker_container_test.go
@@ -610,6 +610,93 @@ func TestAccDockerContainer_upload(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccContainerRunning("docker_container.foo", &c),
 					testCheck,
+					resource.TestCheckResourceAttr("docker_container.foo", "name", "tf-test"),
+					resource.TestCheckResourceAttr("docker_container.foo", "upload.#", "1"),
+					// TODO mavogel: although they are in the state they are not found... check fails
+					// resource.TestCheckResourceAttr("docker_container.foo", "upload.0.content", "foo"),
+					// resource.TestCheckResourceAttr("docker_container.foo", "upload.0.content_base64", ""),
+					// resource.TestCheckResourceAttr("docker_container.foo", "upload.0.executable", "true"),
+					// resource.TestCheckResourceAttr("docker_container.foo", "upload.0.file", "/terraform/test.txt"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDockerContainer_uploadLargeBinary(t *testing.T) {
+	var c types.ContainerJSON
+
+	testCheck := func(srcPath, wantedContent, filePerm string) func(*terraform.State) error {
+		return func(*terraform.State) error {
+			client := testAccProvider.Meta().(*ProviderConfig).DockerClient
+
+			r, _, err := client.CopyFromContainer(context.Background(), c.ID, srcPath)
+			if err != nil {
+				return fmt.Errorf("Unable to download a file from container: %s", err)
+			}
+
+			tr := tar.NewReader(r)
+			if header, err := tr.Next(); err != nil {
+				return fmt.Errorf("Unable to read content of tar archive: %s", err)
+			} else {
+				mode := strconv.FormatInt(header.Mode, 8)
+				if !strings.HasSuffix(mode, filePerm) {
+					return fmt.Errorf("File permissions are incorrect: %s", mode)
+				}
+			}
+
+			fbuf := new(bytes.Buffer)
+			fbuf.ReadFrom(tr)
+			gotContent := fbuf.String()
+
+			if wantedContent != gotContent {
+				return fmt.Errorf("file content is invalid: want: %q, got: %q", wantedContent, gotContent)
+			}
+
+			return nil
+		}
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDockerContainerUploadLargeBinaryConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccContainerRunning("docker_container.foo", &c),
+					testCheck("/terraform/test1.txt", "894fc3f56edf2d3a4c5fb5cb71df910f958a2ed8", "744"),
+					testCheck("/terraform/test2.txt", "foobar", "100644"),
+					resource.TestCheckResourceAttr("docker_container.foo", "name", "tf-test"),
+					resource.TestCheckResourceAttr("docker_container.foo", "upload.#", "2"),
+					// resource.TestCheckResourceAttr("docker_container.foo", "upload.0.content", ""),
+					// resource.TestCheckResourceAttr("docker_container.foo", "upload.0.content_base64", "ODk0ZmMzZjU2ZWRmMmQzYTRjNWZiNWNiNzFkZjkxMGY5NThhMmVkOA=="),
+					// resource.TestCheckResourceAttr("docker_container.foo", "upload.0.executable", "true"),
+					// resource.TestCheckResourceAttr("docker_container.foo", "upload.0.file", "/terraform/test1.txt"),
+					// resource.TestCheckResourceAttr("docker_container.foo", "upload.1.content", "foo"),
+					// resource.TestCheckResourceAttr("docker_container.foo", "upload.1.content_base64", ""),
+					// resource.TestCheckResourceAttr("docker_container.foo", "upload.1.executable", "false"),
+					// resource.TestCheckResourceAttr("docker_container.foo", "upload.1.file", "/terraform/test2.txt"),
+				),
+			},
+			// We add a second on purpose to detect if there is a dirty plan
+			// although the file content did not change
+			{
+				Config: testAccDockerContainerUploadLargeBinaryConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccContainerRunning("docker_container.foo", &c),
+					testCheck("/terraform/test1.txt", "894fc3f56edf2d3a4c5fb5cb71df910f958a2ed8", "744"),
+					testCheck("/terraform/test2.txt", "foobar", "100644"),
+					resource.TestCheckResourceAttr("docker_container.foo", "name", "tf-test"),
+					resource.TestCheckResourceAttr("docker_container.foo", "upload.#", "2"),
+					// resource.TestCheckResourceAttr("docker_container.foo", "upload.0.content", ""),
+					// resource.TestCheckResourceAttr("docker_container.foo", "upload.0.content_base64", "ODk0ZmMzZjU2ZWRmMmQzYTRjNWZiNWNiNzFkZjkxMGY5NThhMmVkOA=="),
+					// resource.TestCheckResourceAttr("docker_container.foo", "upload.0.executable", "true"),
+					// resource.TestCheckResourceAttr("docker_container.foo", "upload.0.file", "/terraform/test1.txt"),
+					// resource.TestCheckResourceAttr("docker_container.foo", "upload.1.content", "foo"),
+					// resource.TestCheckResourceAttr("docker_container.foo", "upload.1.content_base64", ""),
+					// resource.TestCheckResourceAttr("docker_container.foo", "upload.1.executable", "false"),
+					// resource.TestCheckResourceAttr("docker_container.foo", "upload.1.file", "/terraform/test2.txt"),
 				),
 			},
 		},
@@ -1531,6 +1618,7 @@ resource "docker_network" "test_network" {
 const testAccDockerContainerUploadConfig = `
 resource "docker_image" "foo" {
 	name = "nginx:latest"
+	keep_locally = true
 }
 
 resource "docker_container" "foo" {
@@ -1541,6 +1629,29 @@ resource "docker_container" "foo" {
 		content = "foo"
 		file = "/terraform/test.txt"
 		executable = true
+	}
+}
+`
+
+const testAccDockerContainerUploadLargeBinaryConfig = `
+resource "docker_image" "foo" {
+	name         = "nginx:latest"
+	keep_locally = true
+}
+
+resource "docker_container" "foo" {
+	name  = "tf-test"
+	image = "${docker_image.foo.latest}"
+
+	upload {
+		content_base64 = "${base64encode("894fc3f56edf2d3a4c5fb5cb71df910f958a2ed8")}"
+		file           = "/terraform/test1.txt"
+		executable     = true
+	}
+
+	upload {
+		content = "foobar"
+		file    = "/terraform/test2.txt"
 	}
 }
 `

--- a/docker/resource_docker_container_test.go
+++ b/docker/resource_docker_container_test.go
@@ -722,8 +722,9 @@ func TestAccDockerContainer_multipleUploadContentsConfig(t *testing.T) {
 				}
 				
 				resource "docker_container" "foo" {
-					name  = "tf-test"
-					image = "${docker_image.foo.latest}"
+					name     = "tf-test"
+					image    = "${docker_image.foo.latest}"
+					must_run = "false"
 				
 					upload {
 						content        = "foobar"
@@ -752,8 +753,9 @@ func TestAccDockerContainer_noUploadContentsConfig(t *testing.T) {
 				}
 				
 				resource "docker_container" "foo" {
-					name  = "tf-test"
-					image = "${docker_image.foo.latest}"
+					name     = "tf-test"
+					image    = "${docker_image.foo.latest}"
+					must_run = "false"
 				
 					upload {
 						file           = "/terraform/test1.txt"

--- a/website/docs/r/container.html.markdown
+++ b/website/docs/r/container.html.markdown
@@ -204,12 +204,12 @@ One of `from_container`, `host_path` or `volume_name` must be set.
 ### File Upload
 
 `upload` is a block within the configuration that can be repeated to specify
-files to upload to the container before starting it. If bot `content` or `content_base64` are set, the `base64` one
-will be taken. Currently conflicts within lists and sets are not supported yet. Details see [here](https://github.com/hashicorp/terraform-plugin-sdk/issues/71) 
+files to upload to the container before starting it. Only one of `content` or `content_base64` can be set and at least
+one of them hast to be set.
 Each `upload` supports the following
 
-* `content` - (Optional, string) Literal string value to use as the object content, which will be uploaded as UTF-8-encoded text.
-* `content_base64` - (Optional, string) Base64-encoded data that will be decoded and uploaded as raw bytes for the object content. This allows safely uploading non-UTF8 binary data, but is recommended only for larger binary content such as the result of the `base64encode` interpolation function with small text strings See [here](https://github.com/terraform-providers/terraform-provider-docker/issues/48#issuecomment-374174588) for the reason.
+* `content` - (Optional, string, conflicts with `content_base64`) Literal string value to use as the object content, which will be uploaded as UTF-8-encoded text.
+* `content_base64` - (Optional, string, conflicts with `content`) Base64-encoded data that will be decoded and uploaded as raw bytes for the object content. This allows safely uploading non-UTF8 binary data, but is recommended only for larger binary content such as the result of the `base64encode` interpolation function. See [here](https://github.com/terraform-providers/terraform-provider-docker/issues/48#issuecomment-374174588) for the reason.
 * `file` - (Required, string) path to a file in the container.
 * `executable` - (Optional, bool) If true, the file will be uploaded with user
   executable permission.

--- a/website/docs/r/container.html.markdown
+++ b/website/docs/r/container.html.markdown
@@ -207,8 +207,8 @@ One of `from_container`, `host_path` or `volume_name` must be set.
 files to upload to the container before starting it. Either `content` or `content_base64` has to be set.
 Each `upload` supports the following
 
-* `content` - (Optional, string, conflicts with `content_base64`) A content of a file to upload. This should be used for small strings.
-* `content_base64` - (Optional, string, conflicts with `content`) A base64-encoded content of a large file to upload. See [here](https://github.com/terraform-providers/terraform-provider-docker/issues/48#issuecomment-374174588) for the reason.
+* `content` - (Optional, string, conflicts with `content_base64`) Literal string value to use as the object content, which will be uploaded as UTF-8-encoded text.
+* `content_base64` - (Optional, string, conflicts with `content`) Base64-encoded data that will be decoded and uploaded as raw bytes for the object content. This allows safely uploading non-UTF8 binary data, but is recommended only for no too large content such as the result of the `base64encode` interpolation function with small text strings See [here](https://github.com/terraform-providers/terraform-provider-docker/issues/48#issuecomment-374174588) for the reason.
 * `file` - (Required, string) path to a file in the container.
 * `executable` - (Optional, bool) If true, the file will be uploaded with user
   executable permission.

--- a/website/docs/r/container.html.markdown
+++ b/website/docs/r/container.html.markdown
@@ -204,11 +204,12 @@ One of `from_container`, `host_path` or `volume_name` must be set.
 ### File Upload
 
 `upload` is a block within the configuration that can be repeated to specify
-files to upload to the container before starting it. Either `content` or `content_base64` has to be set.
+files to upload to the container before starting it. If bot `content` or `content_base64` are set, the `base64` one
+will be taken. Currently conflicts within lists and sets are not supported yet. Details see [here](https://github.com/hashicorp/terraform-plugin-sdk/issues/71) 
 Each `upload` supports the following
 
-* `content` - (Optional, string, conflicts with `content_base64`) Literal string value to use as the object content, which will be uploaded as UTF-8-encoded text.
-* `content_base64` - (Optional, string, conflicts with `content`) Base64-encoded data that will be decoded and uploaded as raw bytes for the object content. This allows safely uploading non-UTF8 binary data, but is recommended only for no too large content such as the result of the `base64encode` interpolation function with small text strings See [here](https://github.com/terraform-providers/terraform-provider-docker/issues/48#issuecomment-374174588) for the reason.
+* `content` - (Optional, string) Literal string value to use as the object content, which will be uploaded as UTF-8-encoded text.
+* `content_base64` - (Optional, string) Base64-encoded data that will be decoded and uploaded as raw bytes for the object content. This allows safely uploading non-UTF8 binary data, but is recommended only for larger binary content such as the result of the `base64encode` interpolation function with small text strings See [here](https://github.com/terraform-providers/terraform-provider-docker/issues/48#issuecomment-374174588) for the reason.
 * `file` - (Required, string) path to a file in the container.
 * `executable` - (Optional, bool) If true, the file will be uploaded with user
   executable permission.

--- a/website/docs/r/container.html.markdown
+++ b/website/docs/r/container.html.markdown
@@ -204,10 +204,11 @@ One of `from_container`, `host_path` or `volume_name` must be set.
 ### File Upload
 
 `upload` is a block within the configuration that can be repeated to specify
-files to upload to the container before starting it.
+files to upload to the container before starting it. Either `content` or `content_base64` has to be set.
 Each `upload` supports the following
 
-* `content` - (Required, string) A content of a file to upload.
+* `content` - (Optional, string, conflicts with `content_base64`) A content of a file to upload. This should be used for small strings.
+* `content_base64` - (Optional, string, conflicts with `content`) A base64-encoded content of a large file to upload. See [here](https://github.com/terraform-providers/terraform-provider-docker/issues/48#issuecomment-374174588) for the reason.
 * `file` - (Required, string) path to a file in the container.
 * `executable` - (Optional, bool) If true, the file will be uploaded with user
   executable permission.


### PR DESCRIPTION
### Current fixes
- [x] Fixes #48 by introducing a new `content_base64` property for the upload of larger binaries into a container
- [x] I still need to fix the issue by checking the state of the `upload` set. Waiting for feedback => will be addressed separately in https://github.com/hashicorp/terraform-plugin-sdk/issues/196

### Steps to reproduces
- check out the `fix-binary-upload` branch, uncomment the [lines](https://github.com/terraform-providers/terraform-provider-docker/pull/194/files#diff-6338b0235b8cfe8182bac07219a91c40R616) of the `resource_docker_container_test.go` file and run
```sh
make testacc_setup
TF_LOG=INFO TF_ACC=1 go test -v ./docker -run ^TestAccDockerContainer_upload$ -timeout 360s
```
- you will see in the log of the test, so the properties are actually written into the state
```
  upload.# = 1
  upload.0.content = foo
  upload.0.content_base64 = 
  upload.0.executable = true
  upload.0.file = /terraform/test.txt
```
- but actually the check fails:
```go
resource.Test(t, resource.TestCase{
		PreCheck:  func() { testAccPreCheck(t) },
		Providers: testAccProviders,
		Steps: []resource.TestStep{
			{
				Config: testAccDockerContainerUploadConfig,
				Check: resource.ComposeTestCheckFunc(
					testAccContainerRunning("docker_container.foo", &c),
					testCheck,
					resource.TestCheckResourceAttr("docker_container.foo", "name", "tf-test"),
					resource.TestCheckResourceAttr("docker_container.foo", "upload.#", "1"),
					// TODO mavogel: although they are in the state they are not found... check fails
					// resource.TestCheckResourceAttr("docker_container.foo", "upload.0.content", "foo"),
					// resource.TestCheckResourceAttr("docker_container.foo", "upload.0.content_base64", ""),
					// resource.TestCheckResourceAttr("docker_container.foo", "upload.0.executable", "true"),
					// resource.TestCheckResourceAttr("docker_container.foo", "upload.0.file", "/terraform/test.txt"),
				),
			},
		},
	})
```