### PR TITLE
Updated logdrivers list

### DIFF
--- a/docker/resource_docker_container.go
+++ b/docker/resource_docker_container.go
@@ -574,7 +574,7 @@ func resourceDockerContainer() *schema.Resource {
 				Optional:     true,
 				ForceNew:     true,
 				Default:      "json-file",
-				ValidateFunc: validateStringMatchesPattern(`^(json-file|syslog|journald|gelf|fluentd|awslogs)$`),
+				ValidateFunc: validateStringMatchesPattern(`^(none|local|json-file|syslog|journald|gelf|fluentd|awslogs|splunk|etwlogs|gcplogs|logentries)$`),
 			},
 
 			"log_opts": {


### PR DESCRIPTION
See https://docs.docker.com/config/containers/logging/configure/ section “Supported logging drivers"

Fix #204 specifically.

I don't think backward compatibility should be a concern here.
Worse case scenario, someone tries to use a missing logging driver with an older docker version, and docker will error out.

The provider should not be in the business of managing errors instead of docker. I would even go one step further and suggest this provider removes the whitelist entirely (allowing people who use third-party logging plugin to use it).

Ping @davidjameshowell @mavogel 