### PR TITLE
Support to update docker_container

### DIFF
--- a/docker/resource_docker_container.go
+++ b/docker/resource_docker_container.go
@@ -179,7 +179,6 @@ func resourceDockerContainer() *schema.Resource {
 			"restart": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ForceNew:     true,
 				Default:      "no",
 				ValidateFunc: validateStringMatchesPattern(`^(no|on-failure|always|unless-stopped)$`),
 			},
@@ -187,7 +186,6 @@ func resourceDockerContainer() *schema.Resource {
 			"max_retry_count": {
 				Type:     schema.TypeInt,
 				Optional: true,
-				ForceNew: true,
 			},
 			"working_dir": {
 				Type:     schema.TypeString,
@@ -568,14 +566,12 @@ func resourceDockerContainer() *schema.Resource {
 			"memory": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				ForceNew:     true,
 				ValidateFunc: validateIntegerGeqThan(0),
 			},
 
 			"memory_swap": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				ForceNew:     true,
 				ValidateFunc: validateIntegerGeqThan(-1),
 			},
 
@@ -590,14 +586,12 @@ func resourceDockerContainer() *schema.Resource {
 			"cpu_shares": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				ForceNew:     true,
 				ValidateFunc: validateIntegerGeqThan(0),
 			},
 
 			"cpu_set": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ForceNew:     true,
 				ValidateFunc: validateStringMatchesPattern(`^\d+([,-]\d+)*$`),
 			},
 
@@ -1338,7 +1332,6 @@ func resourceDockerContainerV1() *schema.Resource {
 			"memory": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				ForceNew:     true,
 				ValidateFunc: validateIntegerGeqThan(0),
 			},
 
@@ -1366,7 +1359,6 @@ func resourceDockerContainerV1() *schema.Resource {
 			"cpu_set": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ForceNew:     true,
 				ValidateFunc: validateStringMatchesPattern(`^\d+([,-]\d+)*$`),
 			},
 

--- a/docker/resource_docker_container_funcs.go
+++ b/docker/resource_docker_container_funcs.go
@@ -690,6 +690,8 @@ func resourceDockerContainerUpdate(d *schema.ResourceData, meta interface{}) err
 
 			// TODO update ulimits
 			// Updating ulimits seems not to work well.
+			// It succeeds to run `DockerClient.ContainerUpdate` with `ulimit` but actually `ulimit` aren't changed.
+			// https://github.com/terraform-providers/terraform-provider-docker/pull/236#discussion_r373819536
 			// ulimits := []*units.Ulimit{}
 			// if v, ok := d.GetOk("ulimit"); ok {
 			// 	ulimits = ulimitsToDockerUlimits(v.(*schema.Set))
@@ -704,8 +706,6 @@ func resourceDockerContainerUpdate(d *schema.ResourceData, meta interface{}) err
 					CPUShares:  int64(d.Get("cpu_shares").(int)),
 					Memory:     int64(d.Get("memory").(int)) * 1024 * 1024,
 					CpusetCpus: d.Get("cpu_set").(string),
-					// TODO update ulimits
-					// Updating ulimits seems not to work well.
 					// Ulimits:    ulimits,
 				},
 			}

--- a/docker/resource_docker_container_funcs.go
+++ b/docker/resource_docker_container_funcs.go
@@ -682,7 +682,49 @@ func resourceDockerContainerRead(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceDockerContainerUpdate(d *schema.ResourceData, meta interface{}) error {
-	// TODO call resourceDockerContainerRead here
+	attrs := []string{
+		"restart", "max_retry_count", "cpu_shares", "memory", "cpu_set", "memory_swap",
+	}
+	for _, attr := range attrs {
+		if d.HasChange(attr) {
+
+			// TODO update ulimits
+			// Updating ulimits seems not to work well.
+			// ulimits := []*units.Ulimit{}
+			// if v, ok := d.GetOk("ulimit"); ok {
+			// 	ulimits = ulimitsToDockerUlimits(v.(*schema.Set))
+			// }
+
+			updateConfig := container.UpdateConfig{
+				RestartPolicy: container.RestartPolicy{
+					Name:              d.Get("restart").(string),
+					MaximumRetryCount: d.Get("max_retry_count").(int),
+				},
+				Resources: container.Resources{
+					CPUShares:  int64(d.Get("cpu_shares").(int)),
+					Memory:     int64(d.Get("memory").(int)) * 1024 * 1024,
+					CpusetCpus: d.Get("cpu_set").(string),
+					// TODO update ulimits
+					// Updating ulimits seems not to work well.
+					// Ulimits:    ulimits,
+				},
+			}
+
+			if ms, ok := d.GetOk("memory_swap"); ok {
+				a := int64(ms.(int))
+				if a > 0 {
+					a = a * 1024 * 1024
+				}
+				updateConfig.Resources.MemorySwap = a
+			}
+			client := meta.(*ProviderConfig).DockerClient
+			_, err := client.ContainerUpdate(context.Background(), d.Id(), updateConfig)
+			if err != nil {
+				return fmt.Errorf("Unable to update a container: %w", err)
+			}
+			break
+		}
+	}
 	return nil
 }
 

--- a/docker/resource_docker_container_test.go
+++ b/docker/resource_docker_container_test.go
@@ -67,7 +67,7 @@ func TestAccDockerContainer_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDockerContainerConfig2,
+				Config: testAccDockerContainerUpdateConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccContainerRunning(resourceName, &c),
 				),
@@ -1586,7 +1586,7 @@ resource "docker_container" "foo" {
 }
 `
 
-const testAccDockerContainerConfig2 = `
+const testAccDockerContainerUpdateConfig = `
 resource "docker_image" "foo" {
 	name = "nginx:latest"
 }

--- a/docker/resource_docker_container_test.go
+++ b/docker/resource_docker_container_test.go
@@ -67,6 +67,12 @@ func TestAccDockerContainer_basic(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccDockerContainerConfig2,
+				Check: resource.ComposeTestCheckFunc(
+					testAccContainerRunning(resourceName, &c),
+				),
+			},
+			{
 				ResourceName:      "docker_container.foo",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -1577,6 +1583,24 @@ resource "docker_image" "foo" {
 resource "docker_container" "foo" {
 	name = "tf-test"
 	image = "${docker_image.foo.latest}"
+}
+`
+
+const testAccDockerContainerConfig2 = `
+resource "docker_image" "foo" {
+	name = "nginx:latest"
+}
+
+resource "docker_container" "foo" {
+	name = "tf-test"
+	image = "${docker_image.foo.latest}"
+
+	restart = "on-failure"
+	max_retry_count = 5
+	cpu_shares = 32
+	cpu_set = "0-1"
+	memory = 512
+	memory_swap = 2048
 }
 `
 


### PR DESCRIPTION
This depends on https://github.com/terraform-providers/terraform-provider-docker/pull/234

Support to update `docker_container`

* https://docs.docker.com/engine/api/v1.40/#operation/ContainerUpdate
* https://godoc.org/github.com/docker/docker/client#Client.ContainerUpdate

## Attributes

When the following attributes are updated, the container will be update without recreation.

* restart
* max_retry_count
* cpu_shares
* memory
* cpu_set
* memory_swap

## Note: CI fails but this error has nothing to do with this pull request

https://github.com/terraform-providers/terraform-provider-docker/issues/237
https://github.com/terraform-providers/terraform-provider-docker/pull/234#issuecomment-572841809