### PR TITLE
Allow use of `source` file instead of content / content_base64

### DIFF
--- a/docker/resource_docker_container.go
+++ b/docker/resource_docker_container.go
@@ -704,6 +704,16 @@ func resourceDockerContainer() *schema.Resource {
 							ForceNew: true,
 							Default:  false,
 						},
+						"source": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"source_hash": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
 					},
 				},
 			},
@@ -1451,6 +1461,16 @@ func resourceDockerContainerV1() *schema.Resource {
 							Optional: true,
 							ForceNew: true,
 							Default:  false,
+						},
+						"source": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"source_hash": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
 						},
 					},
 				},

--- a/docker/resource_docker_container_test.go
+++ b/docker/resource_docker_container_test.go
@@ -811,7 +811,7 @@ func TestAccDockerContainer_multipleUploadContentsConfig(t *testing.T) {
 					}
 				}
 				`,
-				ExpectError: regexp.MustCompile(`.*only one of 'content' or 'content_base64' can be specified.*`),
+				ExpectError: regexp.MustCompile(`.*only one of 'content', 'content_base64', or 'source' can be set.*`),
 			},
 		},
 	})
@@ -840,7 +840,7 @@ func TestAccDockerContainer_noUploadContentsConfig(t *testing.T) {
 					}
 				}
 				`,
-				ExpectError: regexp.MustCompile(`.* neither 'content', nor 'content_base64' was set.*`),
+				ExpectError: regexp.MustCompile(`.* one of 'content', 'content_base64', or 'source' must be set.*`),
 			},
 		},
 	})

--- a/scripts/testacc_cleanup.sh
+++ b/scripts/testacc_cleanup.sh
@@ -5,6 +5,7 @@ for p in $(docker container ls -f 'name=private_registry' -q); do docker stop $p
 echo "### stopped private registry ###"
 
 rm -f "$(pwd)/scripts/testing/testingFile"
+rm -f "$(pwd)/scripts/testing/testingFile.base64"
 rm -f "$(pwd)"/scripts/testing/auth/htpasswd
 rm -f "$(pwd)"/scripts/testing/certs/registry_auth.*
 echo "### removed auth and certs ###"

--- a/scripts/testacc_cleanup.sh
+++ b/scripts/testacc_cleanup.sh
@@ -4,6 +4,7 @@ set -e
 for p in $(docker container ls -f 'name=private_registry' -q); do docker stop $p; done
 echo "### stopped private registry ###"
 
+rm -f "$(pwd)/scripts/testing/testingFile"
 rm -f "$(pwd)"/scripts/testing/auth/htpasswd
 rm -f "$(pwd)"/scripts/testing/certs/registry_auth.*
 echo "### removed auth and certs ###"

--- a/scripts/testacc_setup.sh
+++ b/scripts/testacc_setup.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+echo -n "foo" > "$(pwd)/scripts/testing/testingFile"
+
 # Create self signed certs
 mkdir -p "$(pwd)"/scripts/testing/certs
 openssl req \

--- a/scripts/testacc_setup.sh
+++ b/scripts/testacc_setup.sh
@@ -2,6 +2,7 @@
 set -e
 
 echo -n "foo" > "$(pwd)/scripts/testing/testingFile"
+echo -n `base64 $(pwd)/scripts/testing/testingFile` > "$(pwd)/scripts/testing/testingFile.base64"
 
 # Create self signed certs
 mkdir -p "$(pwd)"/scripts/testing/certs

--- a/website/docs/r/container.html.markdown
+++ b/website/docs/r/container.html.markdown
@@ -220,8 +220,10 @@ files to upload to the container before starting it. Only one of `content` or `c
 one of them hast to be set.
 Each `upload` supports the following
 
-* `content` - (Optional, string, conflicts with `content_base64`) Literal string value to use as the object content, which will be uploaded as UTF-8-encoded text.
-* `content_base64` - (Optional, string, conflicts with `content`) Base64-encoded data that will be decoded and uploaded as raw bytes for the object content. This allows safely uploading non-UTF8 binary data, but is recommended only for larger binary content such as the result of the `base64encode` interpolation function. See [here](https://github.com/terraform-providers/terraform-provider-docker/issues/48#issuecomment-374174588) for the reason.
+* `content` - (Optional, string, conflicts with `content_base64` & `source`) Literal string value to use as the object content, which will be uploaded as UTF-8-encoded text.
+* `content_base64` - (Optional, string, conflicts with `content` & `source`) Base64-encoded data that will be decoded and uploaded as raw bytes for the object content. This allows safely uploading non-UTF8 binary data, but is recommended only for larger binary content such as the result of the `base64encode` interpolation function. See [here](https://github.com/terraform-providers/terraform-provider-docker/issues/48#issuecomment-374174588) for the reason.
+* `source` - (Optional, string, conflicts with `content` & `content_base64`) A filename that references a file which will be uploaded as the object content. This allows for large file uploads that do not get stored in state.
+* `source_hash` - (Optional, string) If using `source`, this will force an update if the file content has updated but the filename has not. 
 * `file` - (Required, string) path to a file in the container.
 * `executable` - (Optional, bool) If true, the file will be uploaded with user
   executable permission.


### PR DESCRIPTION
This fixes https://github.com/terraform-providers/terraform-provider-docker/issues/239 by allowing the use of just a filename, rather than the content of a file to be loaded into a container. Apparently anything over 4mb will cause an rpc failure in terraform as of 0.12 (or at least that's what I think I read in the codebase)

Note that I am hardly a Golang expert, and muddled through the best I could.