### PR TITLE
Prevent provider error if auth config is incomplete

### DIFF
--- a/docker/provider.go
+++ b/docker/provider.go
@@ -238,13 +238,13 @@ func providerSetToRegistryAuth(authSet *schema.Set) (*AuthConfigs, error) {
 
 			r, err := os.Open(filePath)
 			if err != nil {
-				return nil, fmt.Errorf("Error opening docker registry config file: %v", err)
+				continue
 			}
 
 			// Parse and set the auth
 			auths, err := newAuthConfigurations(r)
 			if err != nil {
-				return nil, fmt.Errorf("Error parsing docker registry config json: %v", err)
+				continue
 			}
 
 			foundRegistry := false
@@ -257,8 +257,7 @@ func providerSetToRegistryAuth(authSet *schema.Set) (*AuthConfigs, error) {
 			}
 
 			if !foundRegistry {
-				return nil, fmt.Errorf("Couldn't find registry config for '%s' in file: %s",
-					authConfig.ServerAddress, filePath)
+				continue
 			}
 		}
 

--- a/docker/provider_test.go
+++ b/docker/provider_test.go
@@ -2,8 +2,10 @@ package docker
 
 import (
 	"os/exec"
+	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
@@ -22,6 +24,19 @@ func TestProvider(t *testing.T) {
 	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
 		t.Fatalf("err: %s", err)
 	}
+}
+
+func TestAccDockerProvider_WithIncompleteRegistryAuth(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDockerProviderWithIncompleteAuthConfig,
+				ExpectError: regexp.MustCompile(`401 Unauthorized`),
+			},
+		},
+	})
 }
 
 func TestProvider_impl(t *testing.T) {
@@ -47,3 +62,18 @@ func testAccPreCheck(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+const testAccDockerProviderWithIncompleteAuthConfig = `
+provider "docker" {
+	alias = "private"
+	registry_auth {
+	  address  = ""
+	  username = ""
+	  password = ""
+	}
+}
+data "docker_registry_image" "foobar" {
+	provider = "docker.private"
+	name = "localhost:15000/helloworld:1.0"
+}
+`


### PR DESCRIPTION
### Summary

Having an incomplete auth config is a valid case because the auth config may depend on resources which are created after the provider. Then the provider should ignore incomplete configurations.

The current implementation fails early and prevents the deployment of all resources if the auth config is incomplete.

### References
#250 