### PR TITLE
feat: Expose IPv6 properties as attributes

### DIFF
--- a/docker/resource_docker_container.go
+++ b/docker/resource_docker_container.go
@@ -513,6 +513,18 @@ func resourceDockerContainer() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"global_ipv6_address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"global_ipv6_prefix_length": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"ipv6_gateway": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 					},
 				},
 			},
@@ -1288,6 +1300,18 @@ func resourceDockerContainerV1() *schema.Resource {
 							Computed: true,
 						},
 						"gateway": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"global_ipv6_address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"global_ipv6_prefix_length": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"ipv6_gateway": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},

--- a/docker/resource_docker_container_funcs.go
+++ b/docker/resource_docker_container_funcs.go
@@ -845,6 +845,9 @@ func flattenContainerNetworks(in *types.NetworkSettings) []interface{} {
 		m["ip_address"] = networkData.IPAddress
 		m["ip_prefix_length"] = networkData.IPPrefixLen
 		m["gateway"] = networkData.Gateway
+		m["global_ipv6_address"] = networkData.GlobalIPv6Address
+		m["global_ipv6_prefix_length"] = networkData.GlobalIPv6PrefixLen
+		m["ipv6_gateway"] = networkData.IPv6Gateway
 		out = append(out, m)
 	}
 	return out

--- a/docker/resource_docker_container_test.go
+++ b/docker/resource_docker_container_test.go
@@ -1449,6 +1449,9 @@ func TestAccDockerContainer_ipv6address(t *testing.T) {
 					testAccContainerRunning("docker_container.foo", &c),
 					testCheck,
 					resource.TestCheckResourceAttr("docker_container.foo", "name", "tf-test"),
+					resource.TestCheckResourceAttr("docker_container.foo", "network_data.0.global_ipv6_address", "fd00:0:0:0::123"),
+					resource.TestCheckResourceAttr("docker_container.foo", "network_data.0.global_ipv6_prefix_length", "64"),
+					resource.TestCheckResourceAttr("docker_container.foo", "network_data.0.ipv6_gateway", "fd00:0:0:0::f"),
 				),
 			},
 		},
@@ -2138,6 +2141,7 @@ resource "docker_network" "test" {
 	ipv6 = true
 	ipam_config {
 		subnet = "fd00::1/64"
+		gateway = "fd00:0:0:0::f"
 	}
 }
 resource "docker_image" "foo" {


### PR DESCRIPTION
Docker IPv6 addresses can be set automatically, provided the Docker
network in use is set up for it. In this situation, it can be useful to
be able to access the IPv6 properties as attributes.

Resolves https://github.com/terraform-providers/terraform-provider-docker/issues/265