### PR TITLE
Prevent force recreate of container about some attributes

### DIFF
--- a/docker/resource_docker_container.go
+++ b/docker/resource_docker_container.go
@@ -972,6 +972,7 @@ func resourceDockerContainerV1() *schema.Resource {
 			"working_dir": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 			"capabilities": {

--- a/docker/resource_docker_container.go
+++ b/docker/resource_docker_container.go
@@ -600,7 +600,7 @@ func resourceDockerContainer() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
-				Default:  "json-file",
+				Computed: true,
 			},
 
 			"log_opts": {

--- a/docker/resource_docker_container.go
+++ b/docker/resource_docker_container.go
@@ -143,6 +143,7 @@ func resourceDockerContainer() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
@@ -605,6 +606,7 @@ func resourceDockerContainer() *schema.Resource {
 			"log_opts": {
 				Type:     schema.TypeMap,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -899,6 +901,7 @@ func resourceDockerContainerV1() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
@@ -906,6 +909,7 @@ func resourceDockerContainerV1() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
@@ -920,6 +924,7 @@ func resourceDockerContainerV1() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
@@ -928,6 +933,7 @@ func resourceDockerContainerV1() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
@@ -936,6 +942,7 @@ func resourceDockerContainerV1() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
@@ -1235,6 +1242,7 @@ func resourceDockerContainerV1() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
@@ -1337,6 +1345,7 @@ func resourceDockerContainerV1() *schema.Resource {
 			"labels": {
 				Type:     schema.TypeMap,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 

--- a/docker/resource_docker_container_funcs.go
+++ b/docker/resource_docker_container_funcs.go
@@ -642,7 +642,21 @@ func resourceDockerContainerRead(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 	d.Set("ulimit", ulimits)
-	d.Set("env", container.Config.Env)
+
+	// https://github.com/terraform-providers/terraform-provider-docker/issues/242
+	// Comment out to prevent the force replacement.
+	// d.Set("env", container.Config.Env)
+	// labels := make([]interface{}, len(container.Config.Labels))
+	// i := 0
+	// for k, v := range container.Config.Labels {
+	// 	labels[i] = map[string]interface{}{
+	// 		"label": k,
+	// 		"value": v,
+	// 	}
+	// 	i++
+	// }
+	// d.Set("labels", labels)
+
 	d.Set("links", container.HostConfig.Links)
 	d.Set("privileged", container.HostConfig.Privileged)
 	devices := make([]interface{}, len(container.HostConfig.Devices))
@@ -655,16 +669,6 @@ func resourceDockerContainerRead(d *schema.ResourceData, meta interface{}) error
 	}
 	d.Set("devices", devices)
 	// "destroy_grace_seconds" can't be imported
-	labels := make([]interface{}, len(container.Config.Labels))
-	i := 0
-	for k, v := range container.Config.Labels {
-		labels[i] = map[string]interface{}{
-			"label": k,
-			"value": v,
-		}
-		i++
-	}
-	d.Set("labels", labels)
 	d.Set("memory", container.HostConfig.Memory/1024/1024)
 	if container.HostConfig.MemorySwap > 0 {
 		d.Set("memory_swap", container.HostConfig.MemorySwap/1024/1024)

--- a/docker/resource_docker_container_funcs.go
+++ b/docker/resource_docker_container_funcs.go
@@ -643,19 +643,12 @@ func resourceDockerContainerRead(d *schema.ResourceData, meta interface{}) error
 	}
 	d.Set("ulimit", ulimits)
 
+	// We decided not to set the environment variables and labels
+	// because they are taken over from the Docker image and aren't scalar
+	// so it's difficult to treat them well.
+	// For detail, please see the following URLs.
 	// https://github.com/terraform-providers/terraform-provider-docker/issues/242
-	// Comment out to prevent the force replacement.
-	// d.Set("env", container.Config.Env)
-	// labels := make([]interface{}, len(container.Config.Labels))
-	// i := 0
-	// for k, v := range container.Config.Labels {
-	// 	labels[i] = map[string]interface{}{
-	// 		"label": k,
-	// 		"value": v,
-	// 	}
-	// 	i++
-	// }
-	// d.Set("labels", labels)
+	// https://github.com/terraform-providers/terraform-provider-docker/pull/269
 
 	d.Set("links", container.HostConfig.Links)
 	d.Set("privileged", container.HostConfig.Privileged)


### PR DESCRIPTION
https://github.com/terraform-providers/terraform-provider-docker/issues/242
https://github.com/terraform-providers/terraform-provider-docker/issues/270

These bugs are due to https://github.com/terraform-providers/terraform-provider-docker/pull/234 .

* `Computed: true`
  * env
  * labels
  * working_dir
  * command
  * entrypoint
  * user
  * log_opts
  * log_driver
  * dns
  * dns_opts
  * dns_search
* Stop to read the attribute
  * env
  * labels

The environment variables and labels are taken over from the Docker image and it causes unexpected force replacement.
Probably we don't expect to manage such environment variables and labels with Terraform,
so we shouldn't import env and labels.