### PR TITLE
Fix panic to migrate schema of docker_container from v1 to v2

### DIFF
--- a/docker/label_migration.go
+++ b/docker/label_migration.go
@@ -15,7 +15,14 @@ func replaceLabelsMapFieldWithSetField(rawState map[string]interface{}) map[stri
 func migrateContainerLabels(rawState map[string]interface{}) map[string]interface{} {
 	replaceLabelsMapFieldWithSetField(rawState)
 
-	mounts := rawState["mounts"].([]interface{})
+	m, ok := rawState["mounts"]
+	if !ok || m == nil {
+		// https://github.com/terraform-providers/terraform-provider-docker/issues/264
+		rawState["mounts"] = []interface{}{}
+		return rawState
+	}
+
+	mounts := m.([]interface{})
 	newMounts := make([]interface{}, len(mounts))
 	for i, mountI := range mounts {
 		mount := mountI.(map[string]interface{})

--- a/docker/resource_docker_container.go
+++ b/docker/resource_docker_container.go
@@ -559,7 +559,6 @@ func resourceDockerContainer() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				ForceNew: true,
-				Computed: true,
 				Elem:     labelSchema,
 			},
 

--- a/docker/resource_docker_container.go
+++ b/docker/resource_docker_container.go
@@ -456,7 +456,6 @@ func resourceDockerContainer() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				ForceNew: true,
-				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},


### PR DESCRIPTION
Closes #264 

=> https://github.com/terraform-providers/terraform-provider-docker/issues/264#issuecomment-640154237

If "mounts" isn't set in Terraform Configuration with Docker provider v2.6.0,
"mounts" isn't set in State.
So `rawState` doesn't have the key "mounts" and `rawState["mounts"].([]interface{})` occurs panic.