### PR TITLE
Set `Computed: true` and separate files of resourceDockerContainerV1

### DIFF
--- a/docker/resource_docker_container.go
+++ b/docker/resource_docker_container.go
@@ -151,6 +151,7 @@ func resourceDockerContainer() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
@@ -159,6 +160,7 @@ func resourceDockerContainer() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
@@ -192,6 +194,7 @@ func resourceDockerContainer() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 			},
 			"capabilities": {
 				Type:     schema.TypeSet,


### PR DESCRIPTION
#242 
https://github.com/terraform-providers/terraform-provider-docker/pull/269#issuecomment-640697737

In #269, I set `Computed: true` to some attributes to prevent the force recreation.
But I accidentaly updated not `resourceDockerContainer` but `resourceDockerContainerV1` for the following attributes.

* dns
* dns_opts
* working_dir

---

So I set `Computed: true` to these attributes of `resourceDockerContainer`.

And I separate files of `resourceDockerContainer` and `resourceDockerContainerV1` to avoid such a miss.

Sometimes we search a word in the file and jump to the matched line and fix code.
In that case, if `resourceDockerContainer` and `resourceDockerContainerV1` are in the same file,
when we jump to the line we assume the line is in `resourceDockerContainer` but sometimes actually in `resourceDockerContainerV1`.
