### PR TITLE
Add support for init process injection for containers.

### DIFF
--- a/docker/resource_docker_container.go
+++ b/docker/resource_docker_container.go
@@ -812,6 +812,11 @@ func resourceDockerContainer() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Set:         schema.HashString,
 			},
+			"init": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
 		},
 	}
 }

--- a/docker/resource_docker_container_test.go
+++ b/docker/resource_docker_container_test.go
@@ -89,6 +89,7 @@ func TestAccDockerContainer_basic(t *testing.T) {
 					"destroy_grace_seconds",
 					"upload",
 					"remove_volumes",
+					"init",
 
 					// TODO mavogel: Will be done in #219
 					"volumes",
@@ -100,6 +101,48 @@ func TestAccDockerContainer_basic(t *testing.T) {
 		},
 	})
 }
+
+func TestAccDockerContainer_init(t *testing.T) {
+	resourceName := "docker_container.fooinit"
+	var c types.ContainerJSON
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDockerContainerInitConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccContainerRunning(resourceName, &c),
+				),
+			},
+			{
+				ResourceName:      "docker_container.fooinit",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"attach",
+					"log_driver",
+					"logs",
+					"must_run",
+					"restart",
+					"rm",
+					"start",
+					"container_logs",
+					"destroy_grace_seconds",
+					"upload",
+					"remove_volumes",
+
+					// TODO mavogel: Will be done in #219
+					"volumes",
+					"network_alias",
+					"networks",
+					"network_advanced",
+				},
+			},
+		},
+	})
+}
+
 func TestAccDockerContainer_basic_network(t *testing.T) {
 	var c types.ContainerJSON
 	resource.Test(t, resource.TestCase{
@@ -1694,6 +1737,18 @@ resource "docker_image" "foo" {
 resource "docker_container" "foo" {
 	name = "tf-test"
 	image = "${docker_image.foo.latest}"
+}
+`
+
+const testAccDockerContainerInitConfig = `
+resource "docker_image" "fooinit" {
+	name = "nginx:latest"
+}
+
+resource "docker_container" "fooinit" {
+	name = "tf-test"
+	image = "${docker_image.fooinit.latest}"
+	init = true
 }
 `
 

--- a/website/docs/r/container.html.markdown
+++ b/website/docs/r/container.html.markdown
@@ -110,6 +110,7 @@ data is stored in them. See [the docker documentation](https://docs.docker.com/n
 * `sysctls` - (Optional, map) A map of kernel parameters (sysctls) to set in the container.
 * `ipc_mode` - (Optional, string) IPC sharing mode for the container. Possible values are: `none`, `private`, `shareable`, `container:<name|id>` or `host`.
 * `group_add` - (Optional, set of strings) Add additional groups to run as.
+* `init` - (Optional, bool) Configured whether an init process should be injected for this container. If unset this will default to the `dockerd` defaults.
 
 <a id="labels-1"></a>
 #### Labels


### PR DESCRIPTION
This is to implement the same functionality as just issuing a `docker run --init ...`.

I think I got all the required places here but please let me know if I missed something.